### PR TITLE
feat: expand the formula function library to 334 Excel functions

### DIFF
--- a/Chsword.Excel2Object.Tests/BaseFunctionTest.cs
+++ b/Chsword.Excel2Object.Tests/BaseFunctionTest.cs
@@ -18,11 +18,15 @@ public class BaseFunctionTest
         ["It's Rates"] = new[] {"Code", "Rate"}
     };
 
-    protected void TestFunction(Expression<Func<ColumnCellDictionary, object>> exp, string expected)
+    protected static string Convert(Expression<Func<ColumnCellDictionary, object>> exp)
     {
         var convert = new ExpressionConvert(new[] {"One", "Two", "Three", "Four", "Five", "Six"}, 3,
             title => OtherSheets.TryGetValue(title, out var columns) ? columns : null);
-        var ret = convert.Convert(exp);
-        Assert.AreEqual(expected, ret);
+        return convert.Convert(exp);
+    }
+
+    protected void TestFunction(Expression<Func<ColumnCellDictionary, object>> exp, string expected)
+    {
+        Assert.AreEqual(expected, Convert(exp));
     }
 }

--- a/Chsword.Excel2Object.Tests/ExcelFunctionNameTests.cs
+++ b/Chsword.Excel2Object.Tests/ExcelFunctionNameTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Chsword.Excel2Object.Functions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+/// <summary>
+///     Every method of a function interface has to spell a name Excel would accept, since the
+///     translator writes the method name (or its attribute) straight into the formula.
+/// </summary>
+[TestClass]
+public class ExcelFunctionNameTests
+{
+    private static readonly Regex ValidName =
+        new("^(_xlfn\\.(_xlws\\.)?)?[A-Z][A-Z0-9]*(\\.[A-Z][A-Z0-9]*)*$");
+
+    private static MethodInfo[] FunctionMethods()
+    {
+        return typeof(IExcelFunction).Assembly.GetTypes()
+            .Where(t => t.IsInterface && t != typeof(IExcelFunction) && typeof(IExcelFunction).IsAssignableFrom(t))
+            .SelectMany(t => t.GetMethods())
+            .ToArray();
+    }
+
+    private static string NameOf(MethodInfo method)
+    {
+        return method.GetCustomAttribute<ExcelFunctionNameAttribute>()?.StoredName ??
+               method.Name.ToUpperInvariant();
+    }
+
+    [TestMethod]
+    public void EveryFunctionNameLooksLikeAnExcelFunction()
+    {
+        foreach (var method in FunctionMethods())
+            Assert.IsTrue(ValidName.IsMatch(NameOf(method)),
+                $"{method.DeclaringType?.Name}.{method.Name} maps to \"{NameOf(method)}\"");
+    }
+
+    [TestMethod]
+    public void MethodsWhoseNameCannotSpellTheFunctionCarryTheAttribute()
+    {
+        foreach (var method in FunctionMethods().Where(m => NameOf(m).Contains('.')))
+            Assert.IsNotNull(method.GetCustomAttribute<ExcelFunctionNameAttribute>());
+    }
+
+    [TestMethod]
+    public void FunctionsAddedAfterExcel2007AreStoredWithTheirPrefix()
+    {
+        // A workbook that stores the bare name of one of these shows #NAME? instead of a result.
+        var stored = FunctionMethods()
+            .GroupBy(m => $"{m.DeclaringType?.Name}.{m.Name}/{m.GetParameters().Length}")
+            .ToDictionary(g => g.Key, g => NameOf(g.First()));
+        Assert.AreEqual("_xlfn.IFS", stored["IConditionFunction.Ifs/1"]);
+        Assert.AreEqual("_xlfn.STDEV.P", stored["IStatisticsFunction.StDevP/1"]);
+        Assert.AreEqual("_xlfn.XLOOKUP", stored["IReferenceFunction.XLookup/3"]);
+        Assert.AreEqual("_xlfn._xlws.FILTER", stored["IReferenceFunction.Filter/2"]);
+        Assert.AreEqual("_xlfn.TEXTJOIN", stored["ITextFunction.TextJoin/3"]);
+        Assert.AreEqual("_xlfn.DAYS", stored["IDateTimeFunction.Days/2"]);
+        // ... while the functions Excel 2007 already had keep their bare name.
+        Assert.AreEqual("SUMIF", stored["IMathFunction.SumIf/2"]);
+        Assert.AreEqual("VLOOKUP", stored["IReferenceFunction.VLookup/4"]);
+        Assert.AreEqual("STDEV", stored["IStatisticsFunction.StDev/1"]);
+    }
+
+    [TestMethod]
+    public void AllCategoriesAreReachableFromExcelFunctions()
+    {
+        var exposed = typeof(ExcelFunctions).GetProperties()
+            .Select(p => p.PropertyType)
+            .ToArray();
+        foreach (var type in typeof(IExcelFunction).Assembly.GetTypes()
+                     .Where(t => t.IsInterface && t != typeof(IExcelFunction) &&
+                                 typeof(IExcelFunction).IsAssignableFrom(t)))
+            Assert.IsTrue(exposed.Contains(type), $"{type.Name} is not exposed on ExcelFunctions");
+    }
+
+    [TestMethod]
+    public void AllFunctionInterfaceCoversEveryCategory()
+    {
+        foreach (var type in typeof(IExcelFunction).Assembly.GetTypes()
+                     .Where(t => t.IsInterface && t != typeof(IExcelFunction) && t != typeof(IAllFunction) &&
+                                 typeof(IExcelFunction).IsAssignableFrom(t)))
+            Assert.IsTrue(type.IsAssignableFrom(typeof(IAllFunction)),
+                $"IAllFunction does not include {type.Name}");
+    }
+}

--- a/Chsword.Excel2Object.Tests/ExpressionConvertClrMappingTests.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertClrMappingTests.cs
@@ -1,0 +1,128 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+/// <summary>
+///     Plain C# written inside a formula lambda - System.Math, string members, captured variables -
+///     is translated to the Excel function that does the same thing.
+/// </summary>
+[TestClass]
+public class ExpressionConvertClrMappingTests : BaseFunctionTest
+{
+    [TestMethod]
+    public void SystemMathBecomesExcelMath()
+    {
+        TestFunction(c => Math.Abs((int) c["One"]), "ABS(A4)");
+        TestFunction(c => Math.Pow((double) c["One"], 2), "POWER(A4,2)");
+        TestFunction(c => Math.Max((int) c["One"], (int) c["Two"]), "MAX(A4,B4)");
+        TestFunction(c => Math.Log((double) c["One"]), "LN(A4)");
+        // .NET takes (y, x), Excel takes (x_num, y_num)
+        TestFunction(c => Math.Atan2((double) c["One"], (double) c["Two"]), "ATAN2(B4,A4)");
+        TestFunction(c => Math.Ceiling((double) c["One"]), "_xlfn.CEILING.MATH(A4)");
+    }
+
+    [TestMethod]
+    public void StringMembersBecomeTextFunctions()
+    {
+        TestFunction(c => ((string) c["One"]).ToUpper(), "UPPER(A4)");
+        TestFunction(c => ((string) c["One"]).Length, "LEN(A4)");
+        TestFunction(c => ((string) c["One"]).Substring(2), "MID(A4,3,LEN(A4))");
+        TestFunction(c => ((string) c["One"]).Substring(2, 3), "MID(A4,3,3)");
+        TestFunction(c => ((string) c["One"]).Replace("-", "/"), "SUBSTITUTE(A4,\"-\",\"/\")");
+        // FIND and EXACT, because .NET's Contains/StartsWith are case sensitive while Excel's
+        // SEARCH and = are not
+        TestFunction(c => ((string) c["One"]).Contains("xy"), "ISNUMBER(FIND(\"xy\",A4))");
+        TestFunction(c => ((string) c["One"]).StartsWith("xy"), "EXACT(LEFT(A4,LEN(\"xy\")),\"xy\")");
+        TestFunction(c => ((string) c["One"]).EndsWith("xy"), "EXACT(RIGHT(A4,LEN(\"xy\")),\"xy\")");
+        // FIND errors when the text is absent, where .NET returns -1
+        TestFunction(c => ((string) c["One"]).IndexOf("xy"), "IFERROR(FIND(\"xy\",A4)-1,-1)");
+        // the char overloads of the same methods translate the same way
+        TestFunction(c => ((string) c["One"]).Contains('x'), "ISNUMBER(FIND(\"x\",A4))");
+        TestFunction(c => ((string) c["One"]).StartsWith('x'), "EXACT(LEFT(A4,LEN(\"x\")),\"x\")");
+    }
+
+    [TestMethod]
+    public void OverloadsExcelCannotExpressAreNotTranslated()
+    {
+        // silently dropping startIndex or a StringComparison would change what the formula means
+        StringAssert.Contains(Convert(c => ((string) c["One"]).IndexOf("xy", 2)), "unspport");
+        StringAssert.Contains(
+            Convert(c => ((string) c["One"]).StartsWith("xy", StringComparison.OrdinalIgnoreCase)),
+            "unspport");
+        StringAssert.Contains(Convert(c => Math.Round((double) c["One"], 2, MidpointRounding.ToEven)),
+            "unspport");
+        // IsNullOrWhiteSpace counts tabs and the Unicode spaces, Excel's TRIM only the ASCII space
+        StringAssert.Contains(Convert(c => string.IsNullOrWhiteSpace((string) c["One"])), "unspport");
+        // no Excel function rounds halves to even the way Math.Round does...
+        StringAssert.Contains(Convert(c => Math.Round((double) c["One"], 2)), "unspport");
+        StringAssert.Contains(Convert(c => Math.Round((double) c["One"])), "unspport");
+        // ... and Excel's TRIM also collapses runs of spaces inside the text, which Trim() does not
+        StringAssert.Contains(Convert(c => ((string) c["One"]).Trim()), "unspport");
+        // the Excel functions themselves are still reachable when that is what is wanted
+        Assert.AreEqual("ROUND(A4,2)", Convert(c => ExcelFunctions.Math.Round(c["One"], 2)));
+        Assert.AreEqual("TRIM(A4)", Convert(c => ExcelFunctions.Text.Trim(c["One"])));
+        // ... while the plain overloads still do translate
+        Assert.AreEqual("ISNUMBER(FIND(\"xy\",A4))", Convert(c => ((string) c["One"]).Contains("xy")));
+    }
+
+    [TestMethod]
+    public void DateLiteralsKeepSubSecondPrecision()
+    {
+        TestFunction(c => c["One"] > new DateTime(2024, 3, 1, 8, 30, 0),
+            "A4>DATE(2024,3,1)+TIME(8,30,0)");
+        TestFunction(c => c["One"] > new DateTime(2024, 3, 1, 8, 30, 0, 500),
+            "A4>DATE(2024,3,1)+TIME(8,30,0)+5.787037037037037E-06");
+    }
+
+    [TestMethod]
+    public void CapturedVariablesBecomeLiterals()
+    {
+        var rate = 0.25m;
+        var label = "VIP";
+        TestFunction(c => c["One"] * rate, "A4*0.25");
+        TestFunction(c => c["One"] + label, "A4+\"VIP\"");
+    }
+
+    [TestMethod]
+    public void NumbersAreWrittenWithAnInvariantDecimalPoint()
+    {
+        TestFunction(c => c["One"] * 1.5, "A4*1.5");
+        TestFunction(c => c["One"] * 0.125m, "A4*0.125");
+    }
+
+    [TestMethod]
+    public void StringJoinKeepsEmptyEntries()
+    {
+        TestFunction(c => string.Join("-", new[] {(string) c["One"], (string) c["Two"]}),
+            "_xlfn.TEXTJOIN(\"-\",FALSE,A4,B4)");
+    }
+
+    [TestMethod]
+    public void BitwiseOperatorsOnIntegersBecomeTheBitFunctions()
+    {
+        TestFunction(c => (int) c["One"] & 6, "_xlfn.BITAND(A4,6)");
+        TestFunction(c => (int) c["One"] | 6, "_xlfn.BITOR(A4,6)");
+        TestFunction(c => (int) c["One"] ^ 6, "_xlfn.BITXOR(A4,6)");
+    }
+
+    [TestMethod]
+    public void XorOnBooleansIsAFutureFunction()
+    {
+        TestFunction(c => (int) c["One"] > 1 ^ (int) c["Two"] < 2, "_xlfn.XOR(A4>1,B4<2)");
+    }
+
+    [TestMethod]
+    public void ModuloBecomesMod()
+    {
+        TestFunction(c => c["One"] % 2, "MOD(A4,2)");
+    }
+
+    [TestMethod]
+    public void CaretBecomesThePowerOperator()
+    {
+        TestFunction(c => c["One"] ^ 2, "A4^2");
+        TestFunction(c => (c["One"] ^ 2) * 3, "A4^2*3");
+        TestFunction(c => c["One"] ^ (c["Two"] ^ 2), "A4^(B4^2)");
+    }
+}

--- a/Chsword.Excel2Object.Tests/ExpressionConvertDatabaseTests.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertDatabaseTests.cs
@@ -1,0 +1,20 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+[TestClass]
+public class ExpressionConvertDatabaseTests : BaseFunctionTest
+{
+    [TestMethod]
+    public void DatabaseFunctionsTakeTableFieldAndCriteria()
+    {
+        TestFunction(
+            c => ExcelFunctions.Database.DSum(c.Matrix("One", 1, "Three", 9), "Two",
+                c.Matrix("Five", 1, "Six", 2)),
+            "DSUM(A1:C9,\"Two\",E1:F2)");
+        TestFunction(
+            c => ExcelFunctions.Database.DGet(c.Matrix("One", 1, "Three", 9), "Two",
+                c.Matrix("Five", 1, "Six", 2)),
+            "DGET(A1:C9,\"Two\",E1:F2)");
+    }
+}

--- a/Chsword.Excel2Object.Tests/ExpressionConvertDateTimeTests.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertDateTimeTests.cs
@@ -1,0 +1,53 @@
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+[TestClass]
+public class ExpressionConvertDateTimeTests : BaseFunctionTest
+{
+    [TestMethod]
+    public void PartsOfADate()
+    {
+        TestFunction(c => ExcelFunctions.DateAndTime.Year(c["One"]), "YEAR(A4)");
+        TestFunction(c => ExcelFunctions.DateAndTime.WeekNum(c["One"]), "WEEKNUM(A4)");
+        TestFunction(c => ExcelFunctions.DateAndTime.IsoWeekNum(c["One"]), "_xlfn.ISOWEEKNUM(A4)");
+        TestFunction(c => ExcelFunctions.DateAndTime.Weekday(c["One"]), "WEEKDAY(A4)");
+    }
+
+    [TestMethod]
+    public void DateArithmetic()
+    {
+        TestFunction(c => ExcelFunctions.DateAndTime.EDate(c["One"], 3), "EDATE(A4,3)");
+        TestFunction(c => ExcelFunctions.DateAndTime.EoMonth(c["One"], 0), "EOMONTH(A4,0)");
+        TestFunction(c => ExcelFunctions.DateAndTime.Days360(c["One"], c["Two"]), "DAYS360(A4,B4)");
+        TestFunction(c => ExcelFunctions.DateAndTime.DateDif(c["One"], c["Two"], "Y"), "DATEDIF(A4,B4,\"Y\")");
+    }
+
+    [TestMethod]
+    public void WorkingDays()
+    {
+        TestFunction(c => ExcelFunctions.DateAndTime.NetworkDays(c["One"], c["Two"]), "NETWORKDAYS(A4,B4)");
+        TestFunction(
+            c => ExcelFunctions.DateAndTime.NetworkDays(c["One"], c["Two"], c.Matrix("Six", 1, "Six", 20)),
+            "NETWORKDAYS(A4,B4,F1:F20)");
+        TestFunction(c => ExcelFunctions.DateAndTime.NetworkDaysIntl(c["One"], c["Two"], 11),
+            "_xlfn.NETWORKDAYS.INTL(A4,B4,11)");
+        TestFunction(c => ExcelFunctions.DateAndTime.WorkDay(c["One"], 5), "WORKDAY(A4,5)");
+    }
+
+    [TestMethod]
+    public void ClrDateTimeMembers()
+    {
+        TestFunction(c => DateTime.Today, "TODAY()");
+        TestFunction(c => ((DateTime) c["One"]).AddDays(7), "(A4+7)");
+        TestFunction(c => ((DateTime) c["One"]).AddMonths(1), "EDATE(A4,1)");
+        TestFunction(c => ((DateTime) c["One"]).Hour, "HOUR(A4)");
+    }
+
+    [TestMethod]
+    public void DateConstantsBecomeDateCalls()
+    {
+        TestFunction(c => c["One"] > new DateTime(2024, 3, 1), "A4>DATE(2024,3,1)");
+    }
+}

--- a/Chsword.Excel2Object.Tests/ExpressionConvertEngineeringTests.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertEngineeringTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+[TestClass]
+public class ExpressionConvertEngineeringTests : BaseFunctionTest
+{
+    [TestMethod]
+    public void BaseConversions()
+    {
+        TestFunction(c => ExcelFunctions.Engineering.Dec2Hex(c["One"]), "DEC2HEX(A4)");
+        TestFunction(c => ExcelFunctions.Engineering.Hex2Dec(c["One"]), "HEX2DEC(A4)");
+        TestFunction(c => ExcelFunctions.Engineering.Bin2Dec(c["One"]), "BIN2DEC(A4)");
+    }
+
+    [TestMethod]
+    public void BitwiseAndUnits()
+    {
+        TestFunction(c => ExcelFunctions.Engineering.BitAnd(c["One"], 6), "_xlfn.BITAND(A4,6)");
+        TestFunction(c => ExcelFunctions.Engineering.Convert(c["One"], "km", "mi"), "CONVERT(A4,\"km\",\"mi\")");
+        TestFunction(c => ExcelFunctions.Engineering.Delta(c["One"], c["Two"]), "DELTA(A4,B4)");
+    }
+}

--- a/Chsword.Excel2Object.Tests/ExpressionConvertFinancialTests.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertFinancialTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+[TestClass]
+public class ExpressionConvertFinancialTests : BaseFunctionTest
+{
+    [TestMethod]
+    public void Annuities()
+    {
+        TestFunction(c => ExcelFunctions.Financial.Pmt(c["One"], c["Two"], c["Three"]), "PMT(A4,B4,C4)");
+        TestFunction(c => ExcelFunctions.Financial.Pv(c["One"], c["Two"], c["Three"]), "PV(A4,B4,C4)");
+        TestFunction(c => ExcelFunctions.Financial.Fv(c["One"], c["Two"], c["Three"]), "FV(A4,B4,C4)");
+        TestFunction(c => ExcelFunctions.Financial.NPer(c["One"], c["Two"], c["Three"]), "NPER(A4,B4,C4)");
+    }
+
+    [TestMethod]
+    public void CashFlows()
+    {
+        TestFunction(c => ExcelFunctions.Financial.Npv(c["One"], c.Matrix("Two", 2, "Two", 9)),
+            "NPV(A4,B2:B9)");
+        TestFunction(c => ExcelFunctions.Financial.Irr(c.Matrix("Two", 2, "Two", 9)), "IRR(B2:B9)");
+        TestFunction(
+            c => ExcelFunctions.Financial.XIrr(c.Matrix("Two", 2, "Two", 9), c.Matrix("Three", 2, "Three", 9)),
+            "XIRR(B2:B9,C2:C9)");
+    }
+
+    [TestMethod]
+    public void Depreciation()
+    {
+        TestFunction(c => ExcelFunctions.Financial.Sln(c["One"], c["Two"], c["Three"]), "SLN(A4,B4,C4)");
+        TestFunction(c => ExcelFunctions.Financial.Ddb(c["One"], c["Two"], c["Three"], 1), "DDB(A4,B4,C4,1)");
+    }
+}

--- a/Chsword.Excel2Object.Tests/ExpressionConvertInformationTests.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertInformationTests.cs
@@ -1,0 +1,34 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+[TestClass]
+public class ExpressionConvertInformationTests : BaseFunctionTest
+{
+    [TestMethod]
+    public void TypeChecks()
+    {
+        TestFunction(c => ExcelFunctions.Information.IsBlank(c["One"]), "ISBLANK(A4)");
+        TestFunction(c => ExcelFunctions.Information.IsNumber(c["One"]), "ISNUMBER(A4)");
+        TestFunction(c => ExcelFunctions.Information.IsText(c["One"]), "ISTEXT(A4)");
+        TestFunction(c => ExcelFunctions.Information.IsEven(c["One"]), "ISEVEN(A4)");
+        TestFunction(c => ExcelFunctions.Information.IsOdd(c["One"]), "ISODD(A4)");
+    }
+
+    [TestMethod]
+    public void ErrorChecks()
+    {
+        TestFunction(c => ExcelFunctions.Information.IsError(c["One"]), "ISERROR(A4)");
+        TestFunction(c => ExcelFunctions.Information.IsNa(c["One"]), "ISNA(A4)");
+        TestFunction(c => ExcelFunctions.Information.ErrorType(c["One"]), "ERROR.TYPE(A4)");
+        TestFunction(c => ExcelFunctions.Information.Na(), "NA()");
+    }
+
+    [TestMethod]
+    public void CombinedWithIf()
+    {
+        TestFunction(
+            c => ExcelFunctions.Condition.If(ExcelFunctions.Information.IsBlank(c["One"]), 0, c["One"]),
+            "IF(ISBLANK(A4),0,A4)");
+    }
+}

--- a/Chsword.Excel2Object.Tests/ExpressionConvertLogicalTests.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertLogicalTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+[TestClass]
+public class ExpressionConvertLogicalTests : BaseFunctionTest
+{
+    [TestMethod]
+    public void AndOrNotXor()
+    {
+        TestFunction(c => ExcelFunctions.Condition.And(c["One"] > 1, c["Two"] < 2), "AND(A4>1,B4<2)");
+        TestFunction(c => ExcelFunctions.Condition.Or(c["One"] > 1, c["Two"] < 2), "OR(A4>1,B4<2)");
+        TestFunction(c => ExcelFunctions.Condition.Xor(c["One"] > 1, c["Two"] < 2), "_xlfn.XOR(A4>1,B4<2)");
+        TestFunction(c => ExcelFunctions.Condition.Not(c["One"] > 1), "NOT(A4>1)");
+    }
+
+    [TestMethod]
+    public void TrueAndFalse()
+    {
+        TestFunction(c => ExcelFunctions.Condition.True(), "TRUE()");
+        TestFunction(c => ExcelFunctions.Condition.False(), "FALSE()");
+    }
+
+    [TestMethod]
+    public void IfVariants()
+    {
+        TestFunction(c => ExcelFunctions.Condition.If(c["One"] > 1, "y", "n"), "IF(A4>1,\"y\",\"n\")");
+        TestFunction(c => ExcelFunctions.Condition.If(c["One"] > 1, "y"), "IF(A4>1,\"y\")");
+        TestFunction(c => ExcelFunctions.Condition.Ifs(c["One"] > 1, "y", c["One"] > 0, "m"),
+            "_xlfn.IFS(A4>1,\"y\",A4>0,\"m\")");
+        TestFunction(c => ExcelFunctions.Condition.Switch(c["One"], 1, "one", 2, "two"),
+            "_xlfn.SWITCH(A4,1,\"one\",2,\"two\")");
+    }
+
+    [TestMethod]
+    public void ErrorHandling()
+    {
+        TestFunction(c => ExcelFunctions.Condition.IfError(c["One"] / c["Two"], 0), "IFERROR(A4/B4,0)");
+        TestFunction(c => ExcelFunctions.Condition.IfNa(c["One"], ""), "_xlfn.IFNA(A4,\"\")");
+    }
+
+    [TestMethod]
+    public void OperatorsBecomeLogicalFunctions()
+    {
+        TestFunction(c => (int) c["One"] > 1 && (int) c["Two"] < 2, "AND(A4>1,B4<2)");
+        TestFunction(c => (int) c["One"] > 1 || (int) c["Two"] < 2, "OR(A4>1,B4<2)");
+        TestFunction(c => !((int) c["One"] > 1), "NOT(A4>1)");
+    }
+
+    [TestMethod]
+    public void CellConditionsCanBeCombinedWithTheLogicalOperators()
+    {
+        // a cell comparison is a ColumnValue, so && and || only compile because ColumnValue defines
+        // operator true / operator false alongside & and |
+        TestFunction(c => c["One"] > 1 && c["Two"] < 2, "AND(A4>1,B4<2)");
+        TestFunction(c => c["One"] > 1 || c["Two"] < 2, "OR(A4>1,B4<2)");
+        TestFunction(c => c["One"] > 1 | c["Two"] < 2, "OR(A4>1,B4<2)");
+        TestFunction(c => !(c["One"] > 1), "NOT(A4>1)");
+        TestFunction(c => (c["One"] > 1 && c["Two"] < 2) || c["Three"] == 0,
+            "OR(AND(A4>1,B4<2),C4=0)");
+    }
+
+    [TestMethod]
+    public void ConditionalOperatorBecomesIf()
+    {
+        TestFunction(c => (int) c["One"] > 5 ? "bulk" : "single", "IF(A4>5,\"bulk\",\"single\")");
+    }
+}

--- a/Chsword.Excel2Object.Tests/ExpressionConvertLookupTests.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertLookupTests.cs
@@ -1,0 +1,41 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+[TestClass]
+public class ExpressionConvertLookupTests : BaseFunctionTest
+{
+    [TestMethod]
+    public void Lookups()
+    {
+        TestFunction(c => ExcelFunctions.Reference.HLookup(c["One"], c.Matrix("One", 1, "Three", 3), 2),
+            "HLOOKUP(A4,A1:C3,2,FALSE)");
+        TestFunction(
+            c => ExcelFunctions.Reference.XLookup(c["One"], c.Matrix("Two", 2, "Two", 9),
+                c.Matrix("Three", 2, "Three", 9)),
+            "_xlfn.XLOOKUP(A4,B2:B9,C2:C9)");
+        TestFunction(c => ExcelFunctions.Reference.Match(c["One"], c.Matrix("Two", 2, "Two", 9)),
+            "MATCH(A4,B2:B9)");
+    }
+
+    [TestMethod]
+    public void Addressing()
+    {
+        TestFunction(c => ExcelFunctions.Reference.Row(), "ROW()");
+        TestFunction(c => ExcelFunctions.Reference.Row(c["One"]), "ROW(A4)");
+        TestFunction(c => ExcelFunctions.Reference.Rows(c.Matrix("One", 2, "One", 9)), "ROWS(A2:A9)");
+        TestFunction(c => ExcelFunctions.Reference.Indirect("A1"), "INDIRECT(\"A1\")");
+        TestFunction(c => ExcelFunctions.Reference.Offset(c["One"], 1, 0), "OFFSET(A4,1,0)");
+        TestFunction(c => ExcelFunctions.Reference.Hyperlink(c["One"], "open"), "HYPERLINK(A4,\"open\")");
+    }
+
+    [TestMethod]
+    public void DynamicArrays()
+    {
+        TestFunction(c => ExcelFunctions.Reference.Unique(c.Matrix("One", 2, "One", 9)), "_xlfn.UNIQUE(A2:A9)");
+        TestFunction(c => ExcelFunctions.Reference.Sort(c.Matrix("One", 2, "Two", 9)), "_xlfn._xlws.SORT(A2:B9)");
+        TestFunction(c => ExcelFunctions.Reference.Filter(c.Matrix("One", 2, "Two", 9), c["Three"] > 1),
+            "_xlfn._xlws.FILTER(A2:B9,C4>1)");
+        TestFunction(c => ExcelFunctions.Reference.Sequence(10), "_xlfn.SEQUENCE(10)");
+    }
+}

--- a/Chsword.Excel2Object.Tests/ExpressionConvertMathFunctionsTest.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertMathFunctionsTest.cs
@@ -16,4 +16,51 @@ public class ExpressionConvertMathFunctionsTests : BaseFunctionTest
     {
         TestFunction(c => ExcelFunctions.Math.PI(), "PI()");
     }
+
+    [TestMethod]
+    public void Rounding()
+    {
+        TestFunction(c => ExcelFunctions.Math.Round(c["One"], 2), "ROUND(A4,2)");
+        TestFunction(c => ExcelFunctions.Math.RoundUp(c["One"], 0), "ROUNDUP(A4,0)");
+        TestFunction(c => ExcelFunctions.Math.Ceiling(c["One"], 5), "CEILING(A4,5)");
+        TestFunction(c => ExcelFunctions.Math.CeilingMath(c["One"]), "_xlfn.CEILING.MATH(A4)");
+        TestFunction(c => ExcelFunctions.Math.FloorMath(c["One"], 5), "_xlfn.FLOOR.MATH(A4,5)");
+        TestFunction(c => ExcelFunctions.Math.MRound(c["One"], 5), "MROUND(A4,5)");
+        TestFunction(c => ExcelFunctions.Math.Trunc(c["One"], 1), "TRUNC(A4,1)");
+    }
+
+    [TestMethod]
+    public void Arithmetic()
+    {
+        TestFunction(c => ExcelFunctions.Math.Mod(c["One"], 3), "MOD(A4,3)");
+        TestFunction(c => ExcelFunctions.Math.Power(c["One"], 2), "POWER(A4,2)");
+        TestFunction(c => ExcelFunctions.Math.Ln(c["One"]), "LN(A4)");
+        TestFunction(c => ExcelFunctions.Math.Log(c["One"], 2), "LOG(A4,2)");
+        TestFunction(c => ExcelFunctions.Math.Quotient(c["One"], c["Two"]), "QUOTIENT(A4,B4)");
+        TestFunction(c => ExcelFunctions.Math.Gcd(c["One"], c["Two"]), "GCD(A4,B4)");
+    }
+
+    [TestMethod]
+    public void ConditionalSums()
+    {
+        TestFunction(c => ExcelFunctions.Math.SumIf(c.Matrix("One", 2, "One", 9), ">100"),
+            "SUMIF(A2:A9,\">100\")");
+        TestFunction(
+            c => ExcelFunctions.Math.SumIf(c.Matrix("One", 2, "One", 9), ">100", c.Matrix("Two", 2, "Two", 9)),
+            "SUMIF(A2:A9,\">100\",B2:B9)");
+        TestFunction(
+            c => ExcelFunctions.Math.SumIfs(c.Matrix("Two", 2, "Two", 9), c.Matrix("One", 2, "One", 9), ">100"),
+            "SUMIFS(B2:B9,A2:A9,\">100\")");
+        TestFunction(
+            c => ExcelFunctions.Math.SumProduct(c.Matrix("One", 2, "One", 9), c.Matrix("Two", 2, "Two", 9)),
+            "SUMPRODUCT(A2:A9,B2:B9)");
+    }
+
+    [TestMethod]
+    public void Trigonometry()
+    {
+        TestFunction(c => ExcelFunctions.Math.Sin(c["One"]), "SIN(A4)");
+        TestFunction(c => ExcelFunctions.Math.Atan2(c["One"], c["Two"]), "ATAN2(A4,B4)");
+        TestFunction(c => ExcelFunctions.Math.Degrees(c["One"]), "DEGREES(A4)");
+    }
 }

--- a/Chsword.Excel2Object.Tests/ExpressionConvertStatisticsFunctionsTests.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertStatisticsFunctionsTests.cs
@@ -1,0 +1,53 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+[TestClass]
+public class ExpressionConvertStatisticsFunctionsTests : BaseFunctionTest
+{
+    [TestMethod]
+    public void AveragesAndCounts()
+    {
+        TestFunction(c => ExcelFunctions.Statistics.Average(c.Matrix("One", 2, "One", 9)), "AVERAGE(A2:A9)");
+        TestFunction(c => ExcelFunctions.Statistics.Count(c.Matrix("One", 2, "One", 9)), "COUNT(A2:A9)");
+        TestFunction(c => ExcelFunctions.Statistics.CountA(c.Matrix("One", 2, "One", 9)), "COUNTA(A2:A9)");
+        TestFunction(c => ExcelFunctions.Statistics.CountIf(c.Matrix("One", 2, "One", 9), ">3"),
+            "COUNTIF(A2:A9,\">3\")");
+        TestFunction(
+            c => ExcelFunctions.Statistics.AverageIf(c.Matrix("One", 2, "One", 9), ">3",
+                c.Matrix("Two", 2, "Two", 9)),
+            "AVERAGEIF(A2:A9,\">3\",B2:B9)");
+    }
+
+    [TestMethod]
+    public void ExtremesAndOrder()
+    {
+        TestFunction(c => ExcelFunctions.Statistics.Max(c.Matrix("One", 2, "One", 9)), "MAX(A2:A9)");
+        TestFunction(c => ExcelFunctions.Statistics.Min(c["One"], c["Two"]), "MIN(A4,B4)");
+        TestFunction(c => ExcelFunctions.Statistics.Large(c.Matrix("One", 2, "One", 9), 2), "LARGE(A2:A9,2)");
+        TestFunction(c => ExcelFunctions.Statistics.Rank(c["One"], c.Matrix("One", 2, "One", 9)),
+            "RANK(A4,A2:A9)");
+        TestFunction(c => ExcelFunctions.Statistics.RankEq(c["One"], c.Matrix("One", 2, "One", 9), 0),
+            "_xlfn.RANK.EQ(A4,A2:A9,0)");
+    }
+
+    [TestMethod]
+    public void SpreadAndDistribution()
+    {
+        TestFunction(c => ExcelFunctions.Statistics.Median(c.Matrix("One", 2, "One", 9)), "MEDIAN(A2:A9)");
+        TestFunction(c => ExcelFunctions.Statistics.StDevP(c.Matrix("One", 2, "One", 9)), "_xlfn.STDEV.P(A2:A9)");
+        TestFunction(c => ExcelFunctions.Statistics.VarS(c.Matrix("One", 2, "One", 9)), "_xlfn.VAR.S(A2:A9)");
+        TestFunction(
+            c => ExcelFunctions.Statistics.PercentileInc(c.Matrix("One", 2, "One", 9), 0.9), 
+            "_xlfn.PERCENTILE.INC(A2:A9,0.9)");
+        TestFunction(c => ExcelFunctions.Statistics.NormSInv(0.95), "_xlfn.NORM.S.INV(0.95)");
+    }
+
+    [TestMethod]
+    public void SumStillAcceptsRangesAndValues()
+    {
+        TestFunction(c => ExcelFunctions.Statistics.Sum(c.Matrix("One", 1, "Two", 2)), "SUM(A1:B2)");
+        TestFunction(c => ExcelFunctions.Statistics.Sum(c["One"], c.Matrix("Two", 1, "Two", 9)),
+            "SUM(A4,B1:B9)");
+    }
+}

--- a/Chsword.Excel2Object.Tests/ExpressionConvertTest.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertTest.cs
@@ -47,7 +47,8 @@ public class ExpressionConvertTests : BaseFunctionTest
     [TestMethod]
     public void Days()
     {
-        TestFunction(c => DateAndTime.Days(c["One"], c["Two"]), "DAYS(A4,B4)");
+        // DAYS arrived in Excel 2013, so the sheet stores it under the _xlfn. prefix.
+        TestFunction(c => DateAndTime.Days(c["One"], c["Two"]), "_xlfn.DAYS(A4,B4)");
     }
 
     [TestMethod]

--- a/Chsword.Excel2Object.Tests/ExpressionConvertTextFunctionsTests.cs
+++ b/Chsword.Excel2Object.Tests/ExpressionConvertTextFunctionsTests.cs
@@ -1,0 +1,51 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+[TestClass]
+public class ExpressionConvertTextFunctionsTests : BaseFunctionTest
+{
+    [TestMethod]
+    public void Pieces()
+    {
+        TestFunction(c => ExcelFunctions.Text.Left(c["One"], 3), "LEFT(A4,3)");
+        TestFunction(c => ExcelFunctions.Text.Right(c["One"], 3), "RIGHT(A4,3)");
+        TestFunction(c => ExcelFunctions.Text.Mid(c["One"], 2, 3), "MID(A4,2,3)");
+        TestFunction(c => ExcelFunctions.Text.Len(c["One"]), "LEN(A4)");
+        TestFunction(c => ExcelFunctions.Text.LenB(c["One"]), "LENB(A4)");
+    }
+
+    [TestMethod]
+    public void SearchAndEdit()
+    {
+        TestFunction(c => ExcelFunctions.Text.Search("a", c["One"]), "SEARCH(\"a\",A4)");
+        TestFunction(c => ExcelFunctions.Text.Substitute(c["One"], "-", "/"), "SUBSTITUTE(A4,\"-\",\"/\")");
+        TestFunction(c => ExcelFunctions.Text.Replace(c["One"], 1, 2, "xx"), "REPLACE(A4,1,2,\"xx\")");
+        TestFunction(c => ExcelFunctions.Text.Trim(c["One"]), "TRIM(A4)");
+        TestFunction(c => ExcelFunctions.Text.Rept("-", 5), "REPT(\"-\",5)");
+    }
+
+    [TestMethod]
+    public void CaseAndJoin()
+    {
+        TestFunction(c => ExcelFunctions.Text.Upper(c["One"]), "UPPER(A4)");
+        TestFunction(c => ExcelFunctions.Text.Proper(c["One"]), "PROPER(A4)");
+        TestFunction(c => ExcelFunctions.Text.Concat(c["One"], c["Two"]), "_xlfn.CONCAT(A4,B4)");
+        TestFunction(c => ExcelFunctions.Text.TextJoin("-", true, c["One"], c["Two"]),
+            "_xlfn.TEXTJOIN(\"-\",TRUE,A4,B4)");
+    }
+
+    [TestMethod]
+    public void Conversion()
+    {
+        TestFunction(c => ExcelFunctions.Text.Text(c["One"], "0.00"), "TEXT(A4,\"0.00\")");
+        TestFunction(c => ExcelFunctions.Text.Value(c["One"]), "VALUE(A4)");
+        TestFunction(c => ExcelFunctions.Text.Char(65), "CHAR(65)");
+    }
+
+    [TestMethod]
+    public void QuotesInsideTextAreDoubled()
+    {
+        TestFunction(c => ExcelFunctions.Text.Substitute(c["One"], "\"", "'"), "SUBSTITUTE(A4,\"\"\"\",\"'\")");
+    }
+}

--- a/Chsword.Excel2Object.Tests/FormulaExportIntegrationTest.cs
+++ b/Chsword.Excel2Object.Tests/FormulaExportIntegrationTest.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using Chsword.Excel2Object.Functions;
+using Chsword.Excel2Object.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Chsword.Excel2Object.Tests;
+
+/// <summary>
+///     The formulas produced for the newly supported functions have to survive NPOI's formula parser,
+///     which is what actually writes them into the workbook.
+/// </summary>
+[TestClass]
+public class FormulaExportIntegrationTest : BaseExcelTest
+{
+    private static readonly List<Dictionary<string, object>> Rows = new()
+    {
+        new() {["Name"] = "a", ["Qty"] = 4, ["Price"] = 2.5},
+        new() {["Name"] = "b", ["Qty"] = 9, ["Price"] = 1.5}
+    };
+
+    private static byte[] Export(string title, Expression<Func<ColumnCellDictionary, object>> formula)
+    {
+        return new ExcelExporter().ObjectToExcelBytes(Rows, options =>
+        {
+            options.ExcelType = ExcelType.Xlsx;
+            options.FormulaColumns.Add(new FormulaColumn
+            {
+                Title = title,
+                Formula = formula,
+                AfterColumnTitle = "Price"
+            });
+        });
+    }
+
+    [TestMethod]
+    public void NewFunctionsProduceParsableFormulas()
+    {
+        var cases = new List<Expression<Func<ColumnCellDictionary, object>>>
+        {
+            c => ExcelFunctions.Statistics.Average(c.Matrix("Qty", 2, "Qty", 3)),
+            c => ExcelFunctions.Statistics.CountIf(c.Matrix("Qty", 2, "Qty", 3), ">3"),
+            c => ExcelFunctions.Math.SumIf(c.Matrix("Qty", 2, "Qty", 3), ">3", c.Matrix("Price", 2, "Price", 3)),
+            c => ExcelFunctions.Math.Mod(c["Qty"], 2),
+            c => ExcelFunctions.Text.Upper(c["Name"]),
+            c => ExcelFunctions.Text.Text(c["Price"], "0.00"),
+            c => ExcelFunctions.Condition.IfError(c["Price"] / c["Qty"], 0),
+            c => ExcelFunctions.Condition.And(c["Qty"] > 1, c["Price"] > 1),
+            c => ExcelFunctions.Information.IsBlank(c["Name"]),
+            c => ExcelFunctions.DateAndTime.EoMonth(DateTime.Today, 1),
+            c => ExcelFunctions.Financial.Pmt(0.05, 12, c["Price"]),
+            c => ExcelFunctions.Engineering.Dec2Hex(c["Qty"]),
+            c => (int) c["Qty"] > 5 ? "bulk" : "single",
+            c => c["Qty"] % 2,
+            c => c["Price"] ^ 2,
+            // functions Excel gained after 2007, which the sheet has to store with the _xlfn. prefix
+            c => ExcelFunctions.Condition.Ifs(c["Qty"] > 5, "bulk", c["Qty"] > 0, "single"),
+            c => ExcelFunctions.Condition.IfNa(c["Qty"], 0),
+            c => ExcelFunctions.Statistics.StDevP(c.Matrix("Qty", 2, "Qty", 3)),
+            c => ExcelFunctions.Statistics.MaxIfs(c.Matrix("Qty", 2, "Qty", 3),
+                c.Matrix("Price", 2, "Price", 3), ">1"),
+            c => ExcelFunctions.Reference.XLookup(c["Name"], c.Matrix("Name", 2, "Name", 3),
+                c.Matrix("Qty", 2, "Qty", 3)),
+            c => ExcelFunctions.Reference.Filter(c.Matrix("Name", 2, "Qty", 3), c["Qty"] > 1),
+            c => ExcelFunctions.Reference.Sort(c.Matrix("Name", 2, "Qty", 3)),
+            c => ExcelFunctions.Text.TextJoin("-", true, c["Name"], c["Qty"]),
+            c => ExcelFunctions.Text.Concat(c["Name"], c["Qty"]),
+            c => ExcelFunctions.DateAndTime.IsoWeekNum(DateTime.Today),
+            c => ExcelFunctions.Information.IsFormula(c["Price"])
+        };
+        foreach (var formula in cases)
+        {
+            var bytes = Export("F", formula);
+            Assert.IsNotNull(bytes, formula.ToString());
+        }
+    }
+
+    [TestMethod]
+    public void FutureFunctionsAreStoredWithTheirPrefix()
+    {
+        var bytes = Export("Level",
+            c => ExcelFunctions.Condition.Ifs(c["Qty"] > 5, "bulk", c["Qty"] > 0, "single"));
+        using var stream = new System.IO.MemoryStream(bytes);
+        var workbook = new NPOI.XSSF.UserModel.XSSFWorkbook(stream);
+        var sheet = workbook.GetSheetAt(0);
+        var formula = sheet.GetRow(1).Cells.Last().CellFormula;
+        StringAssert.StartsWith(formula, "_xlfn.IFS(");
+    }
+
+    [TestMethod]
+    public void FutureFunctionsKeepTheirPrefixInXlsToo()
+    {
+        // The _xlfn. prefix is how a function outside the file format's own function table is named,
+        // which the 97-2003 format needs at least as much as xlsx does, so it is not gated on type.
+        var bytes = new ExcelExporter().ObjectToExcelBytes(Rows, options =>
+        {
+            options.ExcelType = ExcelType.Xls;
+            options.FormulaColumns.Add(new FormulaColumn
+            {
+                Title = "Level",
+                Formula = (Expression<Func<ColumnCellDictionary, object>>) (c =>
+                    ExcelFunctions.Condition.Ifs(c["Qty"] > 5, "bulk", c["Qty"] > 0, "single")),
+                AfterColumnTitle = "Price"
+            });
+        });
+        using var stream = new System.IO.MemoryStream(bytes);
+        var workbook = new NPOI.HSSF.UserModel.HSSFWorkbook(stream);
+        var formula = workbook.GetSheetAt(0).GetRow(1).Cells.Last().CellFormula;
+        StringAssert.StartsWith(formula, "_xlfn.IFS(");
+    }
+
+    [TestMethod]
+    public void ReadingBackASheetWithAFutureFunctionDoesNotThrow()
+    {
+        // NPOI cannot evaluate the functions it does not implement; reading such a sheet has to
+        // degrade to an empty value rather than fail the whole import.
+        var bytes = Export("Level",
+            c => ExcelFunctions.Condition.Ifs(c["Qty"] > 5, "bulk", c["Qty"] > 0, "single"));
+        var result = ExcelHelper.ExcelToObject<Dictionary<string, object>>(bytes).ToList();
+        Assert.AreEqual(2, result.Count);
+        Assert.AreEqual("a", result[0]["Name"]);
+    }
+
+    [TestMethod]
+    public void ConditionalSumIsComputedByExcel()
+    {
+        var bytes = Export("Total", c => ExcelFunctions.Math.Round(c["Qty"] * c["Price"], 2));
+        var result = ExcelHelper.ExcelToObject<Dictionary<string, object>>(bytes).ToList();
+        Assert.AreEqual("10", result[0]["Total"]);
+        Assert.AreEqual("13.5", result[1]["Total"]);
+    }
+}

--- a/Chsword.Excel2Object.Tests/ModelFormulaTest.cs
+++ b/Chsword.Excel2Object.Tests/ModelFormulaTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
@@ -23,10 +23,13 @@ public class ModelFormulaTest : BaseExcelTest
         [ExcelTitle("Qty")] public int Qty { get; set; }
         [Display(Name = "Ordered")] public DateTime Ordered { get; set; }
         [ExcelTitle("Discount")] public decimal? Discount { get; set; }
+        [ExcelTitle("Paid")] public bool? Paid { get; set; }
+        [ExcelTitle("Code")] public int? Code { get; set; }
         public string Note { get; set; } = "";
     }
 
-    private static readonly string[] Columns = {"Product", "Price", "Qty", "Ordered", "Discount"};
+    private static readonly string[] Columns =
+        {"Product", "Price", "Qty", "Ordered", "Discount", "Paid", "Code"};
 
     private static string Convert(Expression<Func<ColumnCellDictionary, OrderLine, object>> formula)
     {
@@ -45,6 +48,17 @@ public class ModelFormulaTest : BaseExcelTest
         Test((c, m) => m.Qty, "C2");
         Test((c, m) => m.Ordered.Year, "YEAR(D2)");
         Test((c, m) => m.Price * (1 - m.Discount.Value), "B2*(1-E2)");
+    }
+
+    [TestMethod]
+    public void OperatorsOnNullablePropertiesAreNotMistakenForConcatenation()
+    {
+        // a lifted operator is typed bool?/int?, which used to fall through to & (text concatenation)
+        Test((c, m) => m.Paid & m.Paid, "AND(F2,F2)");
+        Test((c, m) => m.Paid | m.Paid, "OR(F2,F2)");
+        Test((c, m) => m.Paid ^ m.Paid, "_xlfn.XOR(F2,F2)");
+        Test((c, m) => m.Code & m.Code, "_xlfn.BITAND(G2,G2)");
+        Test((c, m) => m.Discount.HasValue, "NOT(ISBLANK(E2))");
     }
 
     [TestMethod]

--- a/Chsword.Excel2Object/Chsword.Excel2Object.csproj
+++ b/Chsword.Excel2Object/Chsword.Excel2Object.csproj
@@ -13,7 +13,7 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Product>Chsword.Excel2Object Library</Product>
 		<Authors>Zou Jian</Authors>
-		<Version>2.2.1</Version>
+		<Version>2.3.0</Version>
 		<Copyright>Copyright ? 2014-2025</Copyright>
 		<PackageProjectUrl>https://github.com/chsword/Excel2Object/</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Chsword.Excel2Object/ExcelFunctions.cs
+++ b/Chsword.Excel2Object/ExcelFunctions.cs
@@ -2,14 +2,45 @@
 
 namespace Chsword.Excel2Object;
 
+/// <summary>
+///     The Excel functions usable inside a formula expression, by category.
+/// </summary>
+/// <remarks>
+///     None of these are ever executed: a formula lambda is only ever read as an expression tree and
+///     translated to formula text, so <c>ExcelFunctions.Math.Abs(c["Age"])</c> becomes <c>ABS(B4)</c>.
+/// </remarks>
 public static class ExcelFunctions
 {
+    /// <summary>Every category at once, for formulas that mix them.</summary>
     public static IAllFunction All { get; set; } = null!;
+
+    /// <summary>Logical functions: IF, AND, OR, IFERROR, SWITCH, ...</summary>
     public static IConditionFunction Condition { get; set; } = null!;
+
+    /// <summary>Date and time functions: DATE, EOMONTH, NETWORKDAYS, ...</summary>
     public static IDateTimeFunction DateAndTime { get; set; } = null!;
 
+    /// <summary>Database functions: DSUM, DGET, DCOUNT, ...</summary>
+    public static IDatabaseFunction Database { get; set; } = null!;
+
+    /// <summary>Engineering functions: CONVERT, DEC2BIN, BITAND, ...</summary>
+    public static IEngineeringFunction Engineering { get; set; } = null!;
+
+    /// <summary>Financial functions: PMT, NPV, IRR, ...</summary>
+    public static IFinancialFunction Financial { get; set; } = null!;
+
+    /// <summary>Information functions: ISBLANK, ISNUMBER, NA, ...</summary>
+    public static IInformationFunction Information { get; set; } = null!;
+
+    /// <summary>Math and trigonometry functions: ABS, MOD, POWER, SUMIF, ...</summary>
     public static IMathFunction Math { get; set; } = null!;
+
+    /// <summary>Lookup and reference functions: VLOOKUP, INDEX, MATCH, ...</summary>
     public static IReferenceFunction Reference { get; set; } = null!;
+
+    /// <summary>Statistical functions: SUM, AVERAGE, COUNTIF, MAX, ...</summary>
     public static IStatisticsFunction Statistics { get; set; } = null!;
+
+    /// <summary>Text functions: LEFT, MID, LEN, TEXT, TEXTJOIN, ...</summary>
     public static ITextFunction Text { get; set; } = null!;
 }

--- a/Chsword.Excel2Object/Functions/ColumnValue.cs
+++ b/Chsword.Excel2Object/Functions/ColumnValue.cs
@@ -4,7 +4,16 @@ using System.Runtime.CompilerServices;
 
 namespace Chsword.Excel2Object.Functions;
 
-// this type only used in the Expression
+/// <summary>
+///     A value inside a formula expression: a cell, a literal or the result of a function.
+/// </summary>
+/// <remarks>
+///     This type only ever appears in an expression tree, so none of its members run. The operators
+///     exist to be captured and translated: <c>+ - * /</c> and the comparisons map to the same Excel
+///     operators, <c>&amp;</c> is concatenation, <c>%</c> becomes <c>MOD</c>, <c>^</c> becomes Excel's
+///     power operator (not a bitwise xor), and <c>!</c>, <c>&amp;&amp;</c> and <c>||</c> become
+///     <c>NOT</c>, <c>AND</c> and <c>OR</c>.
+/// </remarks>
 public class ColumnValue
 {
     public static ColumnValue operator +(ColumnValue a, ColumnValue b)
@@ -113,6 +122,79 @@ public class ColumnValue
     }
 
     public static ColumnValue operator -(ColumnValue a)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>Remainder of a division, written as <c>MOD(a,b)</c>.</summary>
+    public static ColumnValue operator %(ColumnValue a, ColumnValue b)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>Raises to a power, written as Excel's <c>^</c> operator.</summary>
+    public static ColumnValue operator ^(ColumnValue a, ColumnValue b)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>Reverses a condition, written as <c>NOT(x)</c>.</summary>
+    public static ColumnValue operator !(ColumnValue a)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>Either condition, written as <c>OR(a,b)</c>.</summary>
+    public static ColumnValue operator |(ColumnValue a, ColumnValue b)
+    {
+        throw new NotImplementedException();
+    }
+
+    // && and || are only allowed on a type that defines operator true / operator false alongside
+    // & and |, so these exist to let cell conditions be written as c["A"] > 1 && c["B"] < 2. Like
+    // every other member here they are only ever captured in an expression tree, never run.
+    public static bool operator true(ColumnValue a)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static bool operator false(ColumnValue a)
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>A range used where a single value is expected, e.g. <c>SUM(A1:B2)</c>.</summary>
+    public static implicit operator ColumnValue(ColumnMatrix operand)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static explicit operator double(ColumnValue operand)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static explicit operator float(ColumnValue operand)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static explicit operator decimal(ColumnValue operand)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static explicit operator long(ColumnValue operand)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static explicit operator bool(ColumnValue operand)
+    {
+        throw new NotImplementedException();
+    }
+
+    public static explicit operator string(ColumnValue operand)
     {
         throw new NotImplementedException();
     }

--- a/Chsword.Excel2Object/Functions/ExcelFunctionNameAttribute.cs
+++ b/Chsword.Excel2Object/Functions/ExcelFunctionNameAttribute.cs
@@ -1,0 +1,40 @@
+namespace Chsword.Excel2Object.Functions;
+
+/// <summary>
+///     How a function interface method is spelled inside a formula, when the method name alone
+///     cannot say it.
+/// </summary>
+/// <remarks>
+///     Two things need spelling out. A name Excel writes with dots, such as <c>STDEV.P</c>, cannot be a
+///     C# method name. And every function Excel gained after the 2007 file format was fixed is *stored*
+///     under a <c>_xlfn.</c> prefix - Excel shows <c>IFS(...)</c> but the sheet holds
+///     <c>_xlfn.IFS(...)</c>, and a workbook that stores the bare name shows <c>#NAME?</c> instead of a
+///     result. <see cref="Future" /> marks those.
+/// </remarks>
+[AttributeUsage(AttributeTargets.Method)]
+public sealed class ExcelFunctionNameAttribute : Attribute
+{
+    /// <summary>Prefix xlsx stores functions added after Excel 2007 under.</summary>
+    public const string FuturePrefix = "_xlfn.";
+
+    /// <summary>Prefix for the ones of those that only work on a worksheet, i.e. SORT and FILTER.</summary>
+    public const string FutureWorksheetPrefix = "_xlfn._xlws.";
+
+    public ExcelFunctionNameAttribute(string name)
+    {
+        Name = name;
+    }
+
+    /// <summary>The function name as Excel shows it, e.g. <c>STDEV.P</c>.</summary>
+    public string Name { get; }
+
+    /// <summary>Whether Excel gained this function after 2007, so that it is stored with a prefix.</summary>
+    public bool Future { get; set; }
+
+    /// <summary>Whether the function is one of the worksheet-only future functions (SORT, FILTER).</summary>
+    public bool WorksheetOnly { get; set; }
+
+    /// <summary>The name to write into the formula, prefix included.</summary>
+    public string StoredName =>
+        Future ? (WorksheetOnly ? FutureWorksheetPrefix : FuturePrefix) + Name : Name;
+}

--- a/Chsword.Excel2Object/Functions/IAllFunction.cs
+++ b/Chsword.Excel2Object/Functions/IAllFunction.cs
@@ -1,4 +1,8 @@
 ﻿namespace Chsword.Excel2Object.Functions;
 
+/// <summary>
+///     Every supported Excel function in one place, for formulas that mix categories.
+/// </summary>
 public interface IAllFunction : IMathFunction, IStatisticsFunction, IConditionFunction, IReferenceFunction,
-    IDateTimeFunction, ITextFunction;
+    IDateTimeFunction, ITextFunction, IInformationFunction, IFinancialFunction, IEngineeringFunction,
+    IDatabaseFunction;

--- a/Chsword.Excel2Object/Functions/IConditionFunction.cs
+++ b/Chsword.Excel2Object/Functions/IConditionFunction.cs
@@ -1,6 +1,55 @@
 ﻿namespace Chsword.Excel2Object.Functions;
 
-public interface IConditionFunction
+/// <summary>
+///     Excel logical functions. See <see cref="IExcelFunction" /> for how these are translated.
+/// </summary>
+/// <remarks>
+///     C# operators are translated too, so the conditions themselves are written naturally:
+///     <c>m.Qty &gt; 5</c>, <c>a &amp;&amp; b</c> (AND), <c>a || b</c> (OR), <c>!a</c> (NOT) and the
+///     conditional operator <c>cond ? x : y</c> (IF).
+/// </remarks>
+public interface IConditionFunction : IExcelFunction
 {
+    /// <summary>IF - one value when the condition holds, another when it does not.</summary>
     ColumnValue If(ColumnValue condition, ColumnValue value1, ColumnValue value2);
+
+    /// <summary>IF - a value when the condition holds.</summary>
+    ColumnValue If(ColumnValue condition, ColumnValue value1);
+
+    /// <summary>IFS - the value of the first condition that holds; pass condition, value pairs.</summary>
+    [ExcelFunctionName("IFS", Future = true)]
+    ColumnValue Ifs(params ColumnValue[] conditionsAndValues);
+
+    /// <summary>SWITCH - matches a value against a list of results; pass match, result pairs.</summary>
+    [ExcelFunctionName("SWITCH", Future = true)]
+    ColumnValue Switch(ColumnValue expression, params ColumnValue[] valuesAndResults);
+
+    /// <summary>IFERROR - a fallback value when the expression is an error.</summary>
+    [ExcelFunctionName("IFERROR")]
+    ColumnValue IfError(ColumnValue val, ColumnValue valueIfError);
+
+    /// <summary>IFNA - a fallback value when the expression is #N/A.</summary>
+    [ExcelFunctionName("IFNA", Future = true)]
+    ColumnValue IfNa(ColumnValue val, ColumnValue valueIfNa);
+
+    /// <summary>AND - TRUE when every argument is true.</summary>
+    ColumnValue And(params ColumnValue[] conditions);
+
+    /// <summary>OR - TRUE when any argument is true.</summary>
+    ColumnValue Or(params ColumnValue[] conditions);
+
+    /// <summary>XOR - TRUE when an odd number of arguments are true.</summary>
+    [ExcelFunctionName("XOR", Future = true)]
+    ColumnValue Xor(params ColumnValue[] conditions);
+
+    /// <summary>NOT - reverses the logic of its argument.</summary>
+    ColumnValue Not(ColumnValue condition);
+
+    /// <summary>TRUE - the logical value TRUE.</summary>
+    [ExcelFunctionName("TRUE")]
+    ColumnValue True();
+
+    /// <summary>FALSE - the logical value FALSE.</summary>
+    [ExcelFunctionName("FALSE")]
+    ColumnValue False();
 }

--- a/Chsword.Excel2Object/Functions/IDatabaseFunction.cs
+++ b/Chsword.Excel2Object/Functions/IDatabaseFunction.cs
@@ -1,0 +1,56 @@
+namespace Chsword.Excel2Object.Functions;
+
+/// <summary>
+///     Excel database functions. Every one of them takes the table, the field to work on and a range
+///     holding the criteria. See <see cref="IExcelFunction" /> for how these are translated.
+/// </summary>
+public interface IDatabaseFunction : IExcelFunction
+{
+    /// <summary>DSUM - sums the values of a field for the rows that meet the criteria.</summary>
+    [ExcelFunctionName("DSUM")]
+    ColumnValue DSum(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+
+    /// <summary>DAVERAGE - averages the values of a field for the rows that meet the criteria.</summary>
+    [ExcelFunctionName("DAVERAGE")]
+    ColumnValue DAverage(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+
+    /// <summary>DCOUNT - counts the numeric cells of a field for the rows that meet the criteria.</summary>
+    [ExcelFunctionName("DCOUNT")]
+    ColumnValue DCount(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+
+    /// <summary>DCOUNTA - counts the non empty cells of a field for the rows that meet the criteria.</summary>
+    [ExcelFunctionName("DCOUNTA")]
+    ColumnValue DCountA(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+
+    /// <summary>DGET - the single value of a field for the one row that meets the criteria.</summary>
+    [ExcelFunctionName("DGET")]
+    ColumnValue DGet(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+
+    /// <summary>DMAX - the largest value of a field for the rows that meet the criteria.</summary>
+    [ExcelFunctionName("DMAX")]
+    ColumnValue DMax(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+
+    /// <summary>DMIN - the smallest value of a field for the rows that meet the criteria.</summary>
+    [ExcelFunctionName("DMIN")]
+    ColumnValue DMin(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+
+    /// <summary>DPRODUCT - multiplies the values of a field for the rows that meet the criteria.</summary>
+    [ExcelFunctionName("DPRODUCT")]
+    ColumnValue DProduct(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+
+    /// <summary>DSTDEV - the sample standard deviation of a field for the rows that meet the criteria.</summary>
+    [ExcelFunctionName("DSTDEV")]
+    ColumnValue DStDev(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+
+    /// <summary>DSTDEVP - the population standard deviation of a field for the rows that meet the criteria.</summary>
+    [ExcelFunctionName("DSTDEVP")]
+    ColumnValue DStDevP(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+
+    /// <summary>DVAR - the sample variance of a field for the rows that meet the criteria.</summary>
+    [ExcelFunctionName("DVAR")]
+    ColumnValue DVar(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+
+    /// <summary>DVARP - the population variance of a field for the rows that meet the criteria.</summary>
+    [ExcelFunctionName("DVARP")]
+    ColumnValue DVarP(ColumnMatrix database, ColumnValue field, ColumnMatrix criteria);
+}

--- a/Chsword.Excel2Object/Functions/IDateTimeFunction.cs
+++ b/Chsword.Excel2Object/Functions/IDateTimeFunction.cs
@@ -1,21 +1,131 @@
 ﻿namespace Chsword.Excel2Object.Functions;
 
-public interface IDateTimeFunction
+/// <summary>
+///     Excel date and time functions. See <see cref="IExcelFunction" /> for how these are translated.
+/// </summary>
+public interface IDateTimeFunction : IExcelFunction
 {
+    // ---- building dates and times ----
+
+    /// <summary>DATE - the date of the given year, month and day.</summary>
     ColumnValue Date(ColumnValue year, ColumnValue month, ColumnValue day);
-    ColumnValue DateDif(ColumnValue start, ColumnValue end, string unit);
-    ColumnValue Days(ColumnValue start, ColumnValue end);
+
+    /// <summary>DATEVALUE - converts a date written as text to a date.</summary>
     ColumnValue DateValue(ColumnValue date);
-    ColumnValue Now();
+
+    /// <summary>TIME - the time of the given hour, minute and second.</summary>
     ColumnValue Time(ColumnValue hour, ColumnValue minute, ColumnValue second);
+
+    /// <summary>TIMEVALUE - converts a time written as text to a time.</summary>
     ColumnValue TimeValue(ColumnValue time);
+
+    /// <summary>NOW - the current date and time.</summary>
+    ColumnValue Now();
+
+    /// <summary>TODAY - the current date.</summary>
     ColumnValue Today();
-    ColumnValue Weekday(ColumnValue date, ColumnValue firstDay);
+
+    // ---- parts of a date ----
+
+    /// <summary>YEAR - the year of a date.</summary>
     ColumnValue Year(ColumnValue date);
-    ColumnValue YearFrac(ColumnValue start, ColumnValue end, string unit);
-    ColumnValue Hour(ColumnValue time);
-    ColumnValue Minute(ColumnValue time);
-    ColumnValue Second(ColumnValue time);
+
+    /// <summary>MONTH - the month of a date.</summary>
     ColumnValue Month(ColumnValue date);
+
+    /// <summary>DAY - the day of a date.</summary>
     ColumnValue Day(ColumnValue date);
+
+    /// <summary>HOUR - the hour of a time.</summary>
+    ColumnValue Hour(ColumnValue time);
+
+    /// <summary>MINUTE - the minute of a time.</summary>
+    ColumnValue Minute(ColumnValue time);
+
+    /// <summary>SECOND - the second of a time.</summary>
+    ColumnValue Second(ColumnValue time);
+
+    /// <summary>WEEKDAY - the day of the week of a date, 1 for Sunday.</summary>
+    ColumnValue Weekday(ColumnValue date);
+
+    /// <summary>WEEKDAY - the day of the week of a date, numbered by <paramref name="firstDay" />.</summary>
+    ColumnValue Weekday(ColumnValue date, ColumnValue firstDay);
+
+    /// <summary>WEEKNUM - the week of the year a date falls in.</summary>
+    [ExcelFunctionName("WEEKNUM")]
+    ColumnValue WeekNum(ColumnValue date);
+
+    /// <summary>WEEKNUM - the week of the year, with the week numbering scheme of <paramref name="returnType" />.</summary>
+    [ExcelFunctionName("WEEKNUM")]
+    ColumnValue WeekNum(ColumnValue date, ColumnValue returnType);
+
+    /// <summary>ISOWEEKNUM - the ISO 8601 week of the year a date falls in.</summary>
+    [ExcelFunctionName("ISOWEEKNUM", Future = true)]
+    ColumnValue IsoWeekNum(ColumnValue date);
+
+    // ---- arithmetic on dates ----
+
+    /// <summary>EDATE - the date the given number of months before or after a date.</summary>
+    [ExcelFunctionName("EDATE")]
+    ColumnValue EDate(ColumnValue date, ColumnValue months);
+
+    /// <summary>EOMONTH - the last day of the month, the given number of months away.</summary>
+    [ExcelFunctionName("EOMONTH")]
+    ColumnValue EoMonth(ColumnValue date, ColumnValue months);
+
+    /// <summary>DAYS - the number of days between two dates.</summary>
+    [ExcelFunctionName("DAYS", Future = true)]
+    ColumnValue Days(ColumnValue start, ColumnValue end);
+
+    /// <summary>DAYS360 - the number of days between two dates on a 360 day year.</summary>
+    [ExcelFunctionName("DAYS360")]
+    ColumnValue Days360(ColumnValue start, ColumnValue end);
+
+    /// <summary>DATEDIF - the difference of two dates in the given unit ("Y", "M", "D", "MD", "YM", "YD").</summary>
+    [ExcelFunctionName("DATEDIF")]
+    ColumnValue DateDif(ColumnValue start, ColumnValue end, string unit);
+
+    /// <summary>YEARFRAC - the fraction of a year between two dates.</summary>
+    [ExcelFunctionName("YEARFRAC")]
+    ColumnValue YearFrac(ColumnValue start, ColumnValue end);
+
+    /// <summary>YEARFRAC - the fraction of a year between two dates, on the given day count basis.</summary>
+    [ExcelFunctionName("YEARFRAC")]
+    ColumnValue YearFrac(ColumnValue start, ColumnValue end, string unit);
+
+    /// <summary>YEARFRAC - the fraction of a year between two dates, on the given day count basis.</summary>
+    [ExcelFunctionName("YEARFRAC")]
+    ColumnValue YearFrac(ColumnValue start, ColumnValue end, ColumnValue basis);
+
+    /// <summary>NETWORKDAYS - the number of working days between two dates.</summary>
+    [ExcelFunctionName("NETWORKDAYS")]
+    ColumnValue NetworkDays(ColumnValue start, ColumnValue end);
+
+    /// <summary>NETWORKDAYS - the number of working days between two dates, excluding holidays.</summary>
+    [ExcelFunctionName("NETWORKDAYS")]
+    ColumnValue NetworkDays(ColumnValue start, ColumnValue end, ColumnMatrix holidays);
+
+    /// <summary>NETWORKDAYS.INTL - working days between two dates, with a custom weekend.</summary>
+    [ExcelFunctionName("NETWORKDAYS.INTL", Future = true)]
+    ColumnValue NetworkDaysIntl(ColumnValue start, ColumnValue end, ColumnValue weekend);
+
+    /// <summary>NETWORKDAYS.INTL - as above, excluding holidays.</summary>
+    [ExcelFunctionName("NETWORKDAYS.INTL", Future = true)]
+    ColumnValue NetworkDaysIntl(ColumnValue start, ColumnValue end, ColumnValue weekend, ColumnMatrix holidays);
+
+    /// <summary>WORKDAY - the date the given number of working days away.</summary>
+    [ExcelFunctionName("WORKDAY")]
+    ColumnValue WorkDay(ColumnValue start, ColumnValue days);
+
+    /// <summary>WORKDAY - the date the given number of working days away, excluding holidays.</summary>
+    [ExcelFunctionName("WORKDAY")]
+    ColumnValue WorkDay(ColumnValue start, ColumnValue days, ColumnMatrix holidays);
+
+    /// <summary>WORKDAY.INTL - as WORKDAY, with a custom weekend.</summary>
+    [ExcelFunctionName("WORKDAY.INTL", Future = true)]
+    ColumnValue WorkDayIntl(ColumnValue start, ColumnValue days, ColumnValue weekend);
+
+    /// <summary>WORKDAY.INTL - as above, excluding holidays.</summary>
+    [ExcelFunctionName("WORKDAY.INTL", Future = true)]
+    ColumnValue WorkDayIntl(ColumnValue start, ColumnValue days, ColumnValue weekend, ColumnMatrix holidays);
 }

--- a/Chsword.Excel2Object/Functions/IEngineeringFunction.cs
+++ b/Chsword.Excel2Object/Functions/IEngineeringFunction.cs
@@ -1,0 +1,85 @@
+namespace Chsword.Excel2Object.Functions;
+
+/// <summary>
+///     Excel engineering functions. See <see cref="IExcelFunction" /> for how these are translated.
+/// </summary>
+public interface IEngineeringFunction : IExcelFunction
+{
+    /// <summary>CONVERT - converts a number from one unit of measurement to another.</summary>
+    ColumnValue Convert(ColumnValue number, ColumnValue fromUnit, ColumnValue toUnit);
+
+    /// <summary>DEC2BIN - converts a decimal number to binary.</summary>
+    [ExcelFunctionName("DEC2BIN")]
+    ColumnValue Dec2Bin(ColumnValue number);
+
+    /// <summary>DEC2OCT - converts a decimal number to octal.</summary>
+    [ExcelFunctionName("DEC2OCT")]
+    ColumnValue Dec2Oct(ColumnValue number);
+
+    /// <summary>DEC2HEX - converts a decimal number to hexadecimal.</summary>
+    [ExcelFunctionName("DEC2HEX")]
+    ColumnValue Dec2Hex(ColumnValue number);
+
+    /// <summary>BIN2DEC - converts a binary number to decimal.</summary>
+    [ExcelFunctionName("BIN2DEC")]
+    ColumnValue Bin2Dec(ColumnValue number);
+
+    /// <summary>BIN2OCT - converts a binary number to octal.</summary>
+    [ExcelFunctionName("BIN2OCT")]
+    ColumnValue Bin2Oct(ColumnValue number);
+
+    /// <summary>BIN2HEX - converts a binary number to hexadecimal.</summary>
+    [ExcelFunctionName("BIN2HEX")]
+    ColumnValue Bin2Hex(ColumnValue number);
+
+    /// <summary>OCT2DEC - converts an octal number to decimal.</summary>
+    [ExcelFunctionName("OCT2DEC")]
+    ColumnValue Oct2Dec(ColumnValue number);
+
+    /// <summary>OCT2BIN - converts an octal number to binary.</summary>
+    [ExcelFunctionName("OCT2BIN")]
+    ColumnValue Oct2Bin(ColumnValue number);
+
+    /// <summary>OCT2HEX - converts an octal number to hexadecimal.</summary>
+    [ExcelFunctionName("OCT2HEX")]
+    ColumnValue Oct2Hex(ColumnValue number);
+
+    /// <summary>HEX2DEC - converts a hexadecimal number to decimal.</summary>
+    [ExcelFunctionName("HEX2DEC")]
+    ColumnValue Hex2Dec(ColumnValue number);
+
+    /// <summary>HEX2BIN - converts a hexadecimal number to binary.</summary>
+    [ExcelFunctionName("HEX2BIN")]
+    ColumnValue Hex2Bin(ColumnValue number);
+
+    /// <summary>HEX2OCT - converts a hexadecimal number to octal.</summary>
+    [ExcelFunctionName("HEX2OCT")]
+    ColumnValue Hex2Oct(ColumnValue number);
+
+    /// <summary>BITAND - the bitwise AND of two numbers.</summary>
+    [ExcelFunctionName("BITAND", Future = true)]
+    ColumnValue BitAnd(ColumnValue number1, ColumnValue number2);
+
+    /// <summary>BITOR - the bitwise OR of two numbers.</summary>
+    [ExcelFunctionName("BITOR", Future = true)]
+    ColumnValue BitOr(ColumnValue number1, ColumnValue number2);
+
+    /// <summary>BITXOR - the bitwise XOR of two numbers.</summary>
+    [ExcelFunctionName("BITXOR", Future = true)]
+    ColumnValue BitXor(ColumnValue number1, ColumnValue number2);
+
+    /// <summary>BITLSHIFT - a number shifted left by the given number of bits.</summary>
+    [ExcelFunctionName("BITLSHIFT", Future = true)]
+    ColumnValue BitLShift(ColumnValue number, ColumnValue shiftAmount);
+
+    /// <summary>BITRSHIFT - a number shifted right by the given number of bits.</summary>
+    [ExcelFunctionName("BITRSHIFT", Future = true)]
+    ColumnValue BitRShift(ColumnValue number, ColumnValue shiftAmount);
+
+    /// <summary>DELTA - 1 when two numbers are equal, 0 otherwise.</summary>
+    ColumnValue Delta(ColumnValue number1, ColumnValue number2);
+
+    /// <summary>GESTEP - 1 when a number is at least the step value, 0 otherwise.</summary>
+    [ExcelFunctionName("GESTEP")]
+    ColumnValue GeStep(ColumnValue number, ColumnValue step);
+}

--- a/Chsword.Excel2Object/Functions/IExcelFunction.cs
+++ b/Chsword.Excel2Object/Functions/IExcelFunction.cs
@@ -1,0 +1,11 @@
+namespace Chsword.Excel2Object.Functions;
+
+/// <summary>
+///     Marker for the interfaces whose methods are translated to Excel functions.
+/// </summary>
+/// <remarks>
+///     Members of these interfaces are never executed: they exist only to be captured in a formula
+///     expression tree, where each call becomes <c>NAME(arg,arg,...)</c>. The Excel name is the method
+///     name in upper case unless <see cref="ExcelFunctionNameAttribute" /> says otherwise.
+/// </remarks>
+public interface IExcelFunction;

--- a/Chsword.Excel2Object/Functions/IFinancialFunction.cs
+++ b/Chsword.Excel2Object/Functions/IFinancialFunction.cs
@@ -1,0 +1,116 @@
+namespace Chsword.Excel2Object.Functions;
+
+/// <summary>
+///     Excel financial functions. See <see cref="IExcelFunction" /> for how these are translated.
+/// </summary>
+public interface IFinancialFunction : IExcelFunction
+{
+    // ---- annuities ----
+
+    /// <summary>PMT - the payment of a loan with constant payments and a constant rate.</summary>
+    [ExcelFunctionName("PMT")]
+    ColumnValue Pmt(ColumnValue rate, ColumnValue nper, ColumnValue pv);
+
+    /// <summary>PMT - as above, with a future value and a payment type.</summary>
+    [ExcelFunctionName("PMT")]
+    ColumnValue Pmt(ColumnValue rate, ColumnValue nper, ColumnValue pv, ColumnValue fv, ColumnValue type);
+
+    /// <summary>IPMT - the interest part of a payment.</summary>
+    [ExcelFunctionName("IPMT")]
+    ColumnValue IPmt(ColumnValue rate, ColumnValue per, ColumnValue nper, ColumnValue pv);
+
+    /// <summary>PPMT - the principal part of a payment.</summary>
+    [ExcelFunctionName("PPMT")]
+    ColumnValue PPmt(ColumnValue rate, ColumnValue per, ColumnValue nper, ColumnValue pv);
+
+    /// <summary>PV - the present value of an investment.</summary>
+    [ExcelFunctionName("PV")]
+    ColumnValue Pv(ColumnValue rate, ColumnValue nper, ColumnValue pmt);
+
+    /// <summary>PV - as above, with a future value and a payment type.</summary>
+    [ExcelFunctionName("PV")]
+    ColumnValue Pv(ColumnValue rate, ColumnValue nper, ColumnValue pmt, ColumnValue fv, ColumnValue type);
+
+    /// <summary>FV - the future value of an investment.</summary>
+    [ExcelFunctionName("FV")]
+    ColumnValue Fv(ColumnValue rate, ColumnValue nper, ColumnValue pmt);
+
+    /// <summary>FV - as above, with a present value and a payment type.</summary>
+    [ExcelFunctionName("FV")]
+    ColumnValue Fv(ColumnValue rate, ColumnValue nper, ColumnValue pmt, ColumnValue pv, ColumnValue type);
+
+    /// <summary>NPER - the number of periods of an investment.</summary>
+    [ExcelFunctionName("NPER")]
+    ColumnValue NPer(ColumnValue rate, ColumnValue pmt, ColumnValue pv);
+
+    /// <summary>RATE - the interest rate per period of an annuity.</summary>
+    [ExcelFunctionName("RATE")]
+    ColumnValue Rate(ColumnValue nper, ColumnValue pmt, ColumnValue pv);
+
+    /// <summary>CUMIPMT - the cumulative interest paid between two periods.</summary>
+    [ExcelFunctionName("CUMIPMT")]
+    ColumnValue CumIPmt(ColumnValue rate, ColumnValue nper, ColumnValue pv, ColumnValue startPeriod,
+        ColumnValue endPeriod, ColumnValue type);
+
+    /// <summary>CUMPRINC - the cumulative principal paid between two periods.</summary>
+    [ExcelFunctionName("CUMPRINC")]
+    ColumnValue CumPrinc(ColumnValue rate, ColumnValue nper, ColumnValue pv, ColumnValue startPeriod,
+        ColumnValue endPeriod, ColumnValue type);
+
+    // ---- cash flows ----
+
+    /// <summary>NPV - the net present value of a series of cash flows.</summary>
+    [ExcelFunctionName("NPV")]
+    ColumnValue Npv(ColumnValue rate, params ColumnValue[] values);
+
+    /// <summary>XNPV - the net present value of cash flows on given dates.</summary>
+    [ExcelFunctionName("XNPV")]
+    ColumnValue XNpv(ColumnValue rate, ColumnMatrix values, ColumnMatrix dates);
+
+    /// <summary>IRR - the internal rate of return of a series of cash flows.</summary>
+    [ExcelFunctionName("IRR")]
+    ColumnValue Irr(ColumnMatrix values);
+
+    /// <summary>IRR - the internal rate of return, starting from a guess.</summary>
+    [ExcelFunctionName("IRR")]
+    ColumnValue Irr(ColumnMatrix values, ColumnValue guess);
+
+    /// <summary>XIRR - the internal rate of return of cash flows on given dates.</summary>
+    [ExcelFunctionName("XIRR")]
+    ColumnValue XIrr(ColumnMatrix values, ColumnMatrix dates);
+
+    /// <summary>MIRR - the internal rate of return with different borrowing and reinvestment rates.</summary>
+    [ExcelFunctionName("MIRR")]
+    ColumnValue MIrr(ColumnMatrix values, ColumnValue financeRate, ColumnValue reinvestRate);
+
+    // ---- depreciation and rates ----
+
+    /// <summary>SLN - the straight line depreciation of an asset for one period.</summary>
+    [ExcelFunctionName("SLN")]
+    ColumnValue Sln(ColumnValue cost, ColumnValue salvage, ColumnValue life);
+
+    /// <summary>SYD - the sum of years digits depreciation for a period.</summary>
+    [ExcelFunctionName("SYD")]
+    ColumnValue Syd(ColumnValue cost, ColumnValue salvage, ColumnValue life, ColumnValue per);
+
+    /// <summary>DB - the fixed declining balance depreciation for a period.</summary>
+    [ExcelFunctionName("DB")]
+    ColumnValue Db(ColumnValue cost, ColumnValue salvage, ColumnValue life, ColumnValue period);
+
+    /// <summary>DDB - the double declining balance depreciation for a period.</summary>
+    [ExcelFunctionName("DDB")]
+    ColumnValue Ddb(ColumnValue cost, ColumnValue salvage, ColumnValue life, ColumnValue period);
+
+    /// <summary>VDB - the declining balance depreciation between two periods.</summary>
+    [ExcelFunctionName("VDB")]
+    ColumnValue Vdb(ColumnValue cost, ColumnValue salvage, ColumnValue life, ColumnValue startPeriod,
+        ColumnValue endPeriod);
+
+    /// <summary>EFFECT - the effective annual interest rate.</summary>
+    [ExcelFunctionName("EFFECT")]
+    ColumnValue Effect(ColumnValue nominalRate, ColumnValue nPeryear);
+
+    /// <summary>NOMINAL - the nominal annual interest rate.</summary>
+    [ExcelFunctionName("NOMINAL")]
+    ColumnValue Nominal(ColumnValue effectRate, ColumnValue nPeryear);
+}

--- a/Chsword.Excel2Object/Functions/IInformationFunction.cs
+++ b/Chsword.Excel2Object/Functions/IInformationFunction.cs
@@ -1,0 +1,91 @@
+namespace Chsword.Excel2Object.Functions;
+
+/// <summary>
+///     Excel information functions. See <see cref="IExcelFunction" /> for how these are translated.
+/// </summary>
+public interface IInformationFunction : IExcelFunction
+{
+    /// <summary>ISBLANK - TRUE when the cell is empty.</summary>
+    [ExcelFunctionName("ISBLANK")]
+    ColumnValue IsBlank(ColumnValue val);
+
+    /// <summary>ISERROR - TRUE for any error value.</summary>
+    [ExcelFunctionName("ISERROR")]
+    ColumnValue IsError(ColumnValue val);
+
+    /// <summary>ISERR - TRUE for any error value except #N/A.</summary>
+    [ExcelFunctionName("ISERR")]
+    ColumnValue IsErr(ColumnValue val);
+
+    /// <summary>ISNA - TRUE for the #N/A error.</summary>
+    [ExcelFunctionName("ISNA")]
+    ColumnValue IsNa(ColumnValue val);
+
+    /// <summary>ISNUMBER - TRUE when the value is a number.</summary>
+    [ExcelFunctionName("ISNUMBER")]
+    ColumnValue IsNumber(ColumnValue val);
+
+    /// <summary>ISTEXT - TRUE when the value is text.</summary>
+    [ExcelFunctionName("ISTEXT")]
+    ColumnValue IsText(ColumnValue val);
+
+    /// <summary>ISNONTEXT - TRUE when the value is not text.</summary>
+    [ExcelFunctionName("ISNONTEXT")]
+    ColumnValue IsNonText(ColumnValue val);
+
+    /// <summary>ISLOGICAL - TRUE when the value is a logical value.</summary>
+    [ExcelFunctionName("ISLOGICAL")]
+    ColumnValue IsLogical(ColumnValue val);
+
+    /// <summary>ISREF - TRUE when the value is a reference.</summary>
+    [ExcelFunctionName("ISREF")]
+    ColumnValue IsRef(ColumnValue val);
+
+    /// <summary>ISFORMULA - TRUE when the cell contains a formula.</summary>
+    [ExcelFunctionName("ISFORMULA", Future = true)]
+    ColumnValue IsFormula(ColumnValue reference);
+
+    /// <summary>ISEVEN - TRUE when the number is even.</summary>
+    [ExcelFunctionName("ISEVEN")]
+    ColumnValue IsEven(ColumnValue val);
+
+    /// <summary>ISODD - TRUE when the number is odd.</summary>
+    [ExcelFunctionName("ISODD")]
+    ColumnValue IsOdd(ColumnValue val);
+
+    /// <summary>NA - the #N/A error value.</summary>
+    [ExcelFunctionName("NA")]
+    ColumnValue Na();
+
+    /// <summary>N - the value converted to a number.</summary>
+    [ExcelFunctionName("N")]
+    ColumnValue N(ColumnValue val);
+
+    /// <summary>TYPE - a number identifying the type of a value.</summary>
+    ColumnValue Type(ColumnValue val);
+
+    /// <summary>ERROR.TYPE - a number identifying an error value.</summary>
+    [ExcelFunctionName("ERROR.TYPE")]
+    ColumnValue ErrorType(ColumnValue val);
+
+    /// <summary>CELL - information about the formatting, location or contents of a cell.</summary>
+    ColumnValue Cell(ColumnValue infoType);
+
+    /// <summary>CELL - information about a given cell.</summary>
+    ColumnValue Cell(ColumnValue infoType, ColumnValue reference);
+
+    /// <summary>SHEET - the number of the sheet of a reference.</summary>
+    [ExcelFunctionName("SHEET", Future = true)]
+    ColumnValue Sheet();
+
+    /// <summary>SHEET - the number of the sheet of a reference.</summary>
+    [ExcelFunctionName("SHEET", Future = true)]
+    ColumnValue Sheet(ColumnValue reference);
+
+    /// <summary>SHEETS - the number of sheets of a reference.</summary>
+    [ExcelFunctionName("SHEETS", Future = true)]
+    ColumnValue Sheets();
+
+    /// <summary>INFO - information about the current operating environment.</summary>
+    ColumnValue Info(ColumnValue typeText);
+}

--- a/Chsword.Excel2Object/Functions/IMathFunction.cs
+++ b/Chsword.Excel2Object/Functions/IMathFunction.cs
@@ -1,33 +1,300 @@
 ﻿namespace Chsword.Excel2Object.Functions;
 
-public interface IMathFunction
+/// <summary>
+///     Excel math and trigonometry functions. See <see cref="IExcelFunction" /> for how these are translated.
+/// </summary>
+public interface IMathFunction : IExcelFunction
 {
-    int Abs(object val);
+    // ---- rounding and sign ----
 
-    /// <summary>
-    ///     正数向上取整至偶数，负数向下取整至偶数
-    /// </summary>
-    int Even(object val);
+    /// <summary>ABS - absolute value.</summary>
+    ColumnValue Abs(ColumnValue val);
 
-    /// <summary>
-    ///     阶乘 / Factorial
-    /// </summary>
-    int Fact(object val);
+    /// <summary>SIGN - 1, 0 or -1 according to the sign of the number.</summary>
+    ColumnValue Sign(ColumnValue val);
 
-    /// <summary>
-    ///     To integer
-    /// </summary>
-    int Int(object val);
+    /// <summary>EVEN - rounds away from zero to the nearest even integer.</summary>
+    ColumnValue Even(ColumnValue val);
 
-    double PI();
+    /// <summary>ODD - rounds away from zero to the nearest odd integer.</summary>
+    ColumnValue Odd(ColumnValue val);
 
-    /// <summary>
-    ///     random 0-1
-    /// </summary>
-    double Rand();
+    /// <summary>INT - rounds down to the nearest integer.</summary>
+    ColumnValue Int(ColumnValue val);
 
-    int Round(object val, object digits);
-    int RoundDown(object val, object digits);
-    int RoundUp(object val, object digits);
-    int Sqrt(object val);
+    /// <summary>TRUNC - truncates to an integer.</summary>
+    ColumnValue Trunc(ColumnValue val);
+
+    /// <summary>TRUNC - truncates to the given number of digits.</summary>
+    ColumnValue Trunc(ColumnValue val, ColumnValue digits);
+
+    /// <summary>ROUND - rounds to the given number of digits.</summary>
+    ColumnValue Round(ColumnValue val, ColumnValue digits);
+
+    /// <summary>ROUNDDOWN - rounds toward zero.</summary>
+    ColumnValue RoundDown(ColumnValue val, ColumnValue digits);
+
+    /// <summary>ROUNDUP - rounds away from zero.</summary>
+    ColumnValue RoundUp(ColumnValue val, ColumnValue digits);
+
+    /// <summary>MROUND - rounds to the nearest multiple of <paramref name="multiple" />.</summary>
+    ColumnValue MRound(ColumnValue val, ColumnValue multiple);
+
+    /// <summary>CEILING - rounds up to the nearest multiple of <paramref name="significance" />.</summary>
+    ColumnValue Ceiling(ColumnValue val, ColumnValue significance);
+
+    /// <summary>CEILING.MATH - rounds up to the nearest integer or multiple of significance.</summary>
+    [ExcelFunctionName("CEILING.MATH", Future = true)]
+    ColumnValue CeilingMath(ColumnValue val);
+
+    /// <summary>CEILING.MATH - rounds up to the nearest multiple of significance.</summary>
+    [ExcelFunctionName("CEILING.MATH", Future = true)]
+    ColumnValue CeilingMath(ColumnValue val, ColumnValue significance);
+
+    /// <summary>CEILING.MATH - rounds up, with control over how negative numbers are handled.</summary>
+    [ExcelFunctionName("CEILING.MATH", Future = true)]
+    ColumnValue CeilingMath(ColumnValue val, ColumnValue significance, ColumnValue mode);
+
+    /// <summary>FLOOR - rounds down to the nearest multiple of <paramref name="significance" />.</summary>
+    ColumnValue Floor(ColumnValue val, ColumnValue significance);
+
+    /// <summary>FLOOR.MATH - rounds down to the nearest integer or multiple of significance.</summary>
+    [ExcelFunctionName("FLOOR.MATH", Future = true)]
+    ColumnValue FloorMath(ColumnValue val);
+
+    /// <summary>FLOOR.MATH - rounds down to the nearest multiple of significance.</summary>
+    [ExcelFunctionName("FLOOR.MATH", Future = true)]
+    ColumnValue FloorMath(ColumnValue val, ColumnValue significance);
+
+    /// <summary>FLOOR.MATH - rounds down, with control over how negative numbers are handled.</summary>
+    [ExcelFunctionName("FLOOR.MATH", Future = true)]
+    ColumnValue FloorMath(ColumnValue val, ColumnValue significance, ColumnValue mode);
+
+    // ---- arithmetic ----
+
+    /// <summary>MOD - remainder of a division.</summary>
+    ColumnValue Mod(ColumnValue number, ColumnValue divisor);
+
+    /// <summary>QUOTIENT - integer part of a division.</summary>
+    ColumnValue Quotient(ColumnValue numerator, ColumnValue denominator);
+
+    /// <summary>POWER - raises a number to a power.</summary>
+    ColumnValue Power(ColumnValue number, ColumnValue power);
+
+    /// <summary>EXP - e raised to a power.</summary>
+    ColumnValue Exp(ColumnValue val);
+
+    /// <summary>LN - natural logarithm.</summary>
+    ColumnValue Ln(ColumnValue val);
+
+    /// <summary>LOG - base 10 logarithm.</summary>
+    ColumnValue Log(ColumnValue val);
+
+    /// <summary>LOG - logarithm to the given base.</summary>
+    ColumnValue Log(ColumnValue val, ColumnValue baseValue);
+
+    /// <summary>LOG10 - base 10 logarithm.</summary>
+    ColumnValue Log10(ColumnValue val);
+
+    /// <summary>SQRT - square root.</summary>
+    ColumnValue Sqrt(ColumnValue val);
+
+    /// <summary>SQRTPI - square root of (number * pi).</summary>
+    [ExcelFunctionName("SQRTPI")]
+    ColumnValue SqrtPi(ColumnValue val);
+
+    /// <summary>PI - the constant pi.</summary>
+    [ExcelFunctionName("PI")]
+    ColumnValue PI();
+
+    /// <summary>GCD - greatest common divisor.</summary>
+    ColumnValue Gcd(params ColumnValue[] values);
+
+    /// <summary>LCM - least common multiple.</summary>
+    ColumnValue Lcm(params ColumnValue[] values);
+
+    /// <summary>FACT - factorial.</summary>
+    ColumnValue Fact(ColumnValue val);
+
+    /// <summary>FACTDOUBLE - double factorial.</summary>
+    ColumnValue FactDouble(ColumnValue val);
+
+    /// <summary>MULTINOMIAL - multinomial coefficient of a set of numbers.</summary>
+    ColumnValue MultiNomial(params ColumnValue[] values);
+
+    /// <summary>COMBIN - number of combinations without repetition.</summary>
+    ColumnValue Combin(ColumnValue number, ColumnValue numberChosen);
+
+    /// <summary>COMBINA - number of combinations with repetition.</summary>
+    [ExcelFunctionName("COMBINA", Future = true)]
+    ColumnValue CombinA(ColumnValue number, ColumnValue numberChosen);
+
+    // ---- aggregation ----
+
+    /// <summary>PRODUCT - multiplies its arguments.</summary>
+    ColumnValue Product(params ColumnValue[] values);
+
+    /// <summary>SUMIF - sums the cells of a range that meet a criteria.</summary>
+    ColumnValue SumIf(ColumnMatrix range, ColumnValue criteria);
+
+    /// <summary>SUMIF - sums <paramref name="sumRange" /> where <paramref name="range" /> meets a criteria.</summary>
+    ColumnValue SumIf(ColumnMatrix range, ColumnValue criteria, ColumnMatrix sumRange);
+
+    /// <summary>SUMIFS - sums the cells that meet several criteria; pass criteria as range, criteria pairs.</summary>
+    ColumnValue SumIfs(ColumnMatrix sumRange, params ColumnValue[] criteria);
+
+    /// <summary>SUMPRODUCT - sum of the products of corresponding cells.</summary>
+    ColumnValue SumProduct(params ColumnValue[] values);
+
+    /// <summary>SUMSQ - sum of the squares of its arguments.</summary>
+    [ExcelFunctionName("SUMSQ")]
+    ColumnValue SumSq(params ColumnValue[] values);
+
+    /// <summary>SERIESSUM - sum of a power series.</summary>
+    [ExcelFunctionName("SERIESSUM")]
+    ColumnValue SeriesSum(ColumnValue x, ColumnValue n, ColumnValue m, ColumnMatrix coefficients);
+
+    /// <summary>SUBTOTAL - subtotal of a list, by function number.</summary>
+    ColumnValue Subtotal(ColumnValue functionNum, params ColumnValue[] values);
+
+    /// <summary>AGGREGATE - aggregate of a list, with control over which values to ignore.</summary>
+    [ExcelFunctionName("AGGREGATE", Future = true)]
+    ColumnValue Aggregate(ColumnValue functionNum, ColumnValue options, params ColumnValue[] values);
+
+    // ---- random ----
+
+    /// <summary>RAND - a random number in [0, 1).</summary>
+    ColumnValue Rand();
+
+    /// <summary>RANDBETWEEN - a random integer between two values.</summary>
+    ColumnValue RandBetween(ColumnValue bottom, ColumnValue top);
+
+    /// <summary>RANDARRAY - an array of random numbers.</summary>
+    [ExcelFunctionName("RANDARRAY", Future = true)]
+    ColumnValue RandArray(ColumnValue rows, ColumnValue columns);
+
+    // ---- number bases ----
+
+    /// <summary>BASE - converts a number to text in the given radix.</summary>
+    [ExcelFunctionName("BASE", Future = true)]
+    ColumnValue Base(ColumnValue number, ColumnValue radix);
+
+    /// <summary>BASE - converts a number to text in the given radix, padded to a minimum length.</summary>
+    [ExcelFunctionName("BASE", Future = true)]
+    ColumnValue Base(ColumnValue number, ColumnValue radix, ColumnValue minLength);
+
+    /// <summary>DECIMAL - converts text in the given radix to a number.</summary>
+    [ExcelFunctionName("DECIMAL", Future = true)]
+    ColumnValue Decimal(ColumnValue text, ColumnValue radix);
+
+    /// <summary>ROMAN - converts a number to roman numerals.</summary>
+    ColumnValue Roman(ColumnValue number);
+
+    /// <summary>ARABIC - converts roman numerals to a number.</summary>
+    [ExcelFunctionName("ARABIC", Future = true)]
+    ColumnValue Arabic(ColumnValue text);
+
+    // ---- matrices ----
+
+    /// <summary>MDETERM - determinant of a matrix.</summary>
+    [ExcelFunctionName("MDETERM")]
+    ColumnValue MDeterm(ColumnMatrix array);
+
+    /// <summary>MINVERSE - inverse of a matrix.</summary>
+    [ExcelFunctionName("MINVERSE")]
+    ColumnValue MInverse(ColumnMatrix array);
+
+    /// <summary>MMULT - matrix product of two arrays.</summary>
+    [ExcelFunctionName("MMULT")]
+    ColumnValue MMult(ColumnMatrix array1, ColumnMatrix array2);
+
+    /// <summary>MUNIT - the identity matrix of the given dimension.</summary>
+    [ExcelFunctionName("MUNIT", Future = true)]
+    ColumnValue MUnit(ColumnValue dimension);
+
+    // ---- trigonometry ----
+
+    /// <summary>SIN - sine.</summary>
+    ColumnValue Sin(ColumnValue val);
+
+    /// <summary>COS - cosine.</summary>
+    ColumnValue Cos(ColumnValue val);
+
+    /// <summary>TAN - tangent.</summary>
+    ColumnValue Tan(ColumnValue val);
+
+    /// <summary>COT - cotangent.</summary>
+    [ExcelFunctionName("COT", Future = true)]
+    ColumnValue Cot(ColumnValue val);
+
+    /// <summary>SEC - secant.</summary>
+    [ExcelFunctionName("SEC", Future = true)]
+    ColumnValue Sec(ColumnValue val);
+
+    /// <summary>CSC - cosecant.</summary>
+    [ExcelFunctionName("CSC", Future = true)]
+    ColumnValue Csc(ColumnValue val);
+
+    /// <summary>ASIN - arcsine.</summary>
+    [ExcelFunctionName("ASIN")]
+    ColumnValue Asin(ColumnValue val);
+
+    /// <summary>ACOS - arccosine.</summary>
+    [ExcelFunctionName("ACOS")]
+    ColumnValue Acos(ColumnValue val);
+
+    /// <summary>ATAN - arctangent.</summary>
+    [ExcelFunctionName("ATAN")]
+    ColumnValue Atan(ColumnValue val);
+
+    /// <summary>ATAN2 - arctangent of the given x and y coordinates.</summary>
+    [ExcelFunctionName("ATAN2")]
+    ColumnValue Atan2(ColumnValue x, ColumnValue y);
+
+    /// <summary>ACOT - arccotangent.</summary>
+    [ExcelFunctionName("ACOT", Future = true)]
+    ColumnValue Acot(ColumnValue val);
+
+    /// <summary>SINH - hyperbolic sine.</summary>
+    ColumnValue Sinh(ColumnValue val);
+
+    /// <summary>COSH - hyperbolic cosine.</summary>
+    ColumnValue Cosh(ColumnValue val);
+
+    /// <summary>TANH - hyperbolic tangent.</summary>
+    ColumnValue Tanh(ColumnValue val);
+
+    /// <summary>COTH - hyperbolic cotangent.</summary>
+    [ExcelFunctionName("COTH", Future = true)]
+    ColumnValue Coth(ColumnValue val);
+
+    /// <summary>SECH - hyperbolic secant.</summary>
+    [ExcelFunctionName("SECH", Future = true)]
+    ColumnValue Sech(ColumnValue val);
+
+    /// <summary>CSCH - hyperbolic cosecant.</summary>
+    [ExcelFunctionName("CSCH", Future = true)]
+    ColumnValue Csch(ColumnValue val);
+
+    /// <summary>ASINH - inverse hyperbolic sine.</summary>
+    [ExcelFunctionName("ASINH")]
+    ColumnValue Asinh(ColumnValue val);
+
+    /// <summary>ACOSH - inverse hyperbolic cosine.</summary>
+    [ExcelFunctionName("ACOSH")]
+    ColumnValue Acosh(ColumnValue val);
+
+    /// <summary>ATANH - inverse hyperbolic tangent.</summary>
+    [ExcelFunctionName("ATANH")]
+    ColumnValue Atanh(ColumnValue val);
+
+    /// <summary>ACOTH - inverse hyperbolic cotangent.</summary>
+    [ExcelFunctionName("ACOTH", Future = true)]
+    ColumnValue Acoth(ColumnValue val);
+
+    /// <summary>DEGREES - converts radians to degrees.</summary>
+    ColumnValue Degrees(ColumnValue angle);
+
+    /// <summary>RADIANS - converts degrees to radians.</summary>
+    ColumnValue Radians(ColumnValue angle);
 }

--- a/Chsword.Excel2Object/Functions/IReferenceFunction.cs
+++ b/Chsword.Excel2Object/Functions/IReferenceFunction.cs
@@ -1,13 +1,185 @@
 ﻿namespace Chsword.Excel2Object.Functions;
 
-public interface IReferenceFunction
+/// <summary>
+///     Excel lookup and reference functions. See <see cref="IExcelFunction" /> for how these are translated.
+/// </summary>
+public interface IReferenceFunction : IExcelFunction
 {
-    ColumnValue Choose(ColumnValue indexNum, params ColumnValue[] values);
-    ColumnValue Index(ColumnMatrix array, ColumnValue rowNum, ColumnValue columnNum);
-    ColumnValue Lookup(ColumnValue val, ColumnMatrix lookupVector, ColumnMatrix resultVector);
+    // ---- lookups ----
 
-    ColumnValue Match(ColumnValue val, ColumnMatrix tableArray, int matchType);
-
+    /// <summary>VLOOKUP - looks a value up in the first column of a range.</summary>
+    [ExcelFunctionName("VLOOKUP")]
     ColumnValue VLookup(ColumnValue val, ColumnMatrix tableArray, ColumnValue colIndexNum,
         bool rangeLookup = false);
+
+    /// <summary>HLOOKUP - looks a value up in the first row of a range.</summary>
+    [ExcelFunctionName("HLOOKUP")]
+    ColumnValue HLookup(ColumnValue val, ColumnMatrix tableArray, ColumnValue rowIndexNum,
+        bool rangeLookup = false);
+
+    /// <summary>XLOOKUP - looks a value up in one range and returns the match from another.</summary>
+    [ExcelFunctionName("XLOOKUP", Future = true)]
+    ColumnValue XLookup(ColumnValue val, ColumnMatrix lookupArray, ColumnMatrix returnArray);
+
+    /// <summary>XLOOKUP - as above, with a value to return when nothing matches.</summary>
+    [ExcelFunctionName("XLOOKUP", Future = true)]
+    ColumnValue XLookup(ColumnValue val, ColumnMatrix lookupArray, ColumnMatrix returnArray,
+        ColumnValue ifNotFound);
+
+    /// <summary>XLOOKUP - as above, with a match mode and a search mode.</summary>
+    [ExcelFunctionName("XLOOKUP", Future = true)]
+    ColumnValue XLookup(ColumnValue val, ColumnMatrix lookupArray, ColumnMatrix returnArray,
+        ColumnValue ifNotFound, ColumnValue matchMode, ColumnValue searchMode);
+
+    /// <summary>LOOKUP - looks a value up in a vector and returns the matching item of another.</summary>
+    ColumnValue Lookup(ColumnValue val, ColumnMatrix lookupVector, ColumnMatrix resultVector);
+
+    /// <summary>MATCH - position of a value within a range.</summary>
+    ColumnValue Match(ColumnValue val, ColumnMatrix tableArray, int matchType);
+
+    /// <summary>
+    ///     MATCH - position of a value within a range, using Excel's default match type: the largest
+    ///     value that is less than or equal to it, in a range sorted ascending. Pass a match type of
+    ///     0 for an exact match.
+    /// </summary>
+    ColumnValue Match(ColumnValue val, ColumnMatrix tableArray);
+
+    /// <summary>XMATCH - position of a value within a range, with a match mode.</summary>
+    [ExcelFunctionName("XMATCH", Future = true)]
+    ColumnValue XMatch(ColumnValue val, ColumnMatrix lookupArray);
+
+    /// <summary>XMATCH - position of a value within a range, with match and search modes.</summary>
+    [ExcelFunctionName("XMATCH", Future = true)]
+    ColumnValue XMatch(ColumnValue val, ColumnMatrix lookupArray, ColumnValue matchMode, ColumnValue searchMode);
+
+    /// <summary>INDEX - the cell of a range at the given row and column.</summary>
+    ColumnValue Index(ColumnMatrix array, ColumnValue rowNum, ColumnValue columnNum);
+
+    /// <summary>INDEX - the cell of a one dimensional range at the given position.</summary>
+    ColumnValue Index(ColumnMatrix array, ColumnValue rowNum);
+
+    /// <summary>CHOOSE - picks a value from a list by its position.</summary>
+    ColumnValue Choose(ColumnValue indexNum, params ColumnValue[] values);
+
+    // ---- addressing ----
+
+    /// <summary>OFFSET - a range shifted from a starting reference.</summary>
+    ColumnValue Offset(ColumnValue reference, ColumnValue rows, ColumnValue cols);
+
+    /// <summary>OFFSET - a range of the given size, shifted from a starting reference.</summary>
+    ColumnValue Offset(ColumnValue reference, ColumnValue rows, ColumnValue cols, ColumnValue height,
+        ColumnValue width);
+
+    /// <summary>INDIRECT - the reference named by a text value.</summary>
+    ColumnValue Indirect(ColumnValue refText);
+
+    /// <summary>ADDRESS - the address of a cell, as text.</summary>
+    ColumnValue Address(ColumnValue rowNum, ColumnValue columnNum);
+
+    /// <summary>ADDRESS - the address of a cell, as text, with an absolute/relative mode.</summary>
+    ColumnValue Address(ColumnValue rowNum, ColumnValue columnNum, ColumnValue absNum);
+
+    /// <summary>ROW - the row number of the formula cell.</summary>
+    ColumnValue Row();
+
+    /// <summary>ROW - the row number of a reference.</summary>
+    ColumnValue Row(ColumnValue reference);
+
+    /// <summary>ROWS - the number of rows of a range.</summary>
+    ColumnValue Rows(ColumnMatrix array);
+
+    /// <summary>COLUMN - the column number of the formula cell.</summary>
+    ColumnValue Column();
+
+    /// <summary>COLUMN - the column number of a reference.</summary>
+    ColumnValue Column(ColumnValue reference);
+
+    /// <summary>COLUMNS - the number of columns of a range.</summary>
+    ColumnValue Columns(ColumnMatrix array);
+
+    /// <summary>AREAS - the number of areas of a reference.</summary>
+    ColumnValue Areas(ColumnValue reference);
+
+    /// <summary>FORMULATEXT - the formula of a cell, as text.</summary>
+    [ExcelFunctionName("FORMULATEXT", Future = true)]
+    ColumnValue FormulaText(ColumnValue reference);
+
+    /// <summary>HYPERLINK - a link to a document or a web address.</summary>
+    ColumnValue Hyperlink(ColumnValue linkLocation);
+
+    /// <summary>HYPERLINK - a link with the text to display.</summary>
+    ColumnValue Hyperlink(ColumnValue linkLocation, ColumnValue friendlyName);
+
+    // ---- dynamic arrays ----
+
+    /// <summary>TRANSPOSE - flips a range from rows to columns.</summary>
+    ColumnValue Transpose(ColumnMatrix array);
+
+    /// <summary>UNIQUE - the distinct values of a range.</summary>
+    [ExcelFunctionName("UNIQUE", Future = true)]
+    ColumnValue Unique(ColumnMatrix array);
+
+    /// <summary>SORT - a range sorted by one of its columns.</summary>
+    [ExcelFunctionName("SORT", Future = true, WorksheetOnly = true)]
+    ColumnValue Sort(ColumnMatrix array);
+
+    /// <summary>SORT - a range sorted by the given index and order.</summary>
+    [ExcelFunctionName("SORT", Future = true, WorksheetOnly = true)]
+    ColumnValue Sort(ColumnMatrix array, ColumnValue sortIndex, ColumnValue sortOrder);
+
+    /// <summary>SORTBY - a range sorted by the values of another range.</summary>
+    [ExcelFunctionName("SORTBY", Future = true)]
+    ColumnValue SortBy(ColumnMatrix array, ColumnMatrix byArray);
+
+    /// <summary>FILTER - the rows of a range that meet a condition.</summary>
+    [ExcelFunctionName("FILTER", Future = true, WorksheetOnly = true)]
+    ColumnValue Filter(ColumnMatrix array, ColumnValue include);
+
+    /// <summary>FILTER - the rows of a range that meet a condition, or a fallback when none do.</summary>
+    [ExcelFunctionName("FILTER", Future = true, WorksheetOnly = true)]
+    ColumnValue Filter(ColumnMatrix array, ColumnValue include, ColumnValue ifEmpty);
+
+    /// <summary>SEQUENCE - a sequence of numbers.</summary>
+    [ExcelFunctionName("SEQUENCE", Future = true)]
+    ColumnValue Sequence(ColumnValue rows);
+
+    /// <summary>SEQUENCE - a sequence of numbers laid out in rows and columns.</summary>
+    [ExcelFunctionName("SEQUENCE", Future = true)]
+    ColumnValue Sequence(ColumnValue rows, ColumnValue columns, ColumnValue start, ColumnValue step);
+
+    /// <summary>TAKE - the first or last rows of a range.</summary>
+    [ExcelFunctionName("TAKE", Future = true)]
+    ColumnValue Take(ColumnMatrix array, ColumnValue rows);
+
+    /// <summary>DROP - a range without its first or last rows.</summary>
+    [ExcelFunctionName("DROP", Future = true)]
+    ColumnValue Drop(ColumnMatrix array, ColumnValue rows);
+
+    /// <summary>CHOOSECOLS - the named columns of a range.</summary>
+    [ExcelFunctionName("CHOOSECOLS", Future = true)]
+    ColumnValue ChooseCols(ColumnMatrix array, params ColumnValue[] colNums);
+
+    /// <summary>CHOOSEROWS - the named rows of a range.</summary>
+    [ExcelFunctionName("CHOOSEROWS", Future = true)]
+    ColumnValue ChooseRows(ColumnMatrix array, params ColumnValue[] rowNums);
+
+    /// <summary>VSTACK - stacks ranges vertically.</summary>
+    [ExcelFunctionName("VSTACK", Future = true)]
+    ColumnValue VStack(params ColumnValue[] arrays);
+
+    /// <summary>HSTACK - stacks ranges horizontally.</summary>
+    [ExcelFunctionName("HSTACK", Future = true)]
+    ColumnValue HStack(params ColumnValue[] arrays);
+
+    /// <summary>TOCOL - a range flattened into one column.</summary>
+    [ExcelFunctionName("TOCOL", Future = true)]
+    ColumnValue ToCol(ColumnMatrix array);
+
+    /// <summary>TOROW - a range flattened into one row.</summary>
+    [ExcelFunctionName("TOROW", Future = true)]
+    ColumnValue ToRow(ColumnMatrix array);
+
+    /// <summary>EXPAND - a range padded to the given size.</summary>
+    [ExcelFunctionName("EXPAND", Future = true)]
+    ColumnValue Expand(ColumnMatrix array, ColumnValue rows, ColumnValue columns, ColumnValue padWith);
 }

--- a/Chsword.Excel2Object/Functions/IStatisticsFunction.cs
+++ b/Chsword.Excel2Object/Functions/IStatisticsFunction.cs
@@ -1,14 +1,321 @@
 ﻿namespace Chsword.Excel2Object.Functions;
 
 /// <summary>
-/// Interface for statistical functions used in Excel to object conversion.
+///     Excel statistical functions. See <see cref="IExcelFunction" /> for how these are translated.
 /// </summary>
-public interface IStatisticsFunction
+/// <remarks>
+///     Ranges are passed as <see cref="ColumnMatrix" /> (for example <c>c.Matrix("One", 1, "Two", 9)</c>);
+///     an implicit conversion lets a range be used anywhere a <see cref="ColumnValue" /> is expected, so
+///     values and ranges can be mixed freely in the argument lists below.
+/// </remarks>
+public interface IStatisticsFunction : IExcelFunction
 {
-    /// <summary>
-    /// Calculates the sum of the specified matrices.
-    /// </summary>
-    /// <param name="matrix">The matrices to sum.</param>
-    /// <returns>A <see cref="ColumnValue"/> representing the sum of the matrices.</returns>
-    ColumnValue Sum(params ColumnMatrix[] matrix);
+    // ---- sums, counts and averages ----
+
+    /// <summary>SUM - adds its arguments.</summary>
+    ColumnValue Sum(params ColumnValue[] values);
+
+    /// <summary>AVERAGE - arithmetic mean of its arguments.</summary>
+    ColumnValue Average(params ColumnValue[] values);
+
+    /// <summary>AVERAGEA - arithmetic mean, counting text and logical values.</summary>
+    [ExcelFunctionName("AVERAGEA")]
+    ColumnValue AverageA(params ColumnValue[] values);
+
+    /// <summary>AVERAGEIF - mean of the cells of a range that meet a criteria.</summary>
+    ColumnValue AverageIf(ColumnMatrix range, ColumnValue criteria);
+
+    /// <summary>AVERAGEIF - mean of <paramref name="averageRange" /> where <paramref name="range" /> meets a criteria.</summary>
+    ColumnValue AverageIf(ColumnMatrix range, ColumnValue criteria, ColumnMatrix averageRange);
+
+    /// <summary>AVERAGEIFS - mean of the cells that meet several criteria; pass criteria as range, criteria pairs.</summary>
+    ColumnValue AverageIfs(ColumnMatrix averageRange, params ColumnValue[] criteria);
+
+    /// <summary>COUNT - counts the numeric cells.</summary>
+    ColumnValue Count(params ColumnValue[] values);
+
+    /// <summary>COUNTA - counts the cells that are not empty.</summary>
+    [ExcelFunctionName("COUNTA")]
+    ColumnValue CountA(params ColumnValue[] values);
+
+    /// <summary>COUNTBLANK - counts the empty cells of a range.</summary>
+    ColumnValue CountBlank(ColumnMatrix range);
+
+    /// <summary>COUNTIF - counts the cells of a range that meet a criteria.</summary>
+    ColumnValue CountIf(ColumnMatrix range, ColumnValue criteria);
+
+    /// <summary>COUNTIFS - counts the cells that meet several criteria; pass criteria as range, criteria pairs.</summary>
+    ColumnValue CountIfs(params ColumnValue[] criteria);
+
+    // ---- extremes and order ----
+
+    /// <summary>MAX - largest value.</summary>
+    ColumnValue Max(params ColumnValue[] values);
+
+    /// <summary>MAXA - largest value, counting text and logical values.</summary>
+    [ExcelFunctionName("MAXA")]
+    ColumnValue MaxA(params ColumnValue[] values);
+
+    /// <summary>MAXIFS - largest value among the cells that meet several criteria.</summary>
+    [ExcelFunctionName("MAXIFS", Future = true)]
+    ColumnValue MaxIfs(ColumnMatrix maxRange, params ColumnValue[] criteria);
+
+    /// <summary>MIN - smallest value.</summary>
+    ColumnValue Min(params ColumnValue[] values);
+
+    /// <summary>MINA - smallest value, counting text and logical values.</summary>
+    [ExcelFunctionName("MINA")]
+    ColumnValue MinA(params ColumnValue[] values);
+
+    /// <summary>MINIFS - smallest value among the cells that meet several criteria.</summary>
+    [ExcelFunctionName("MINIFS", Future = true)]
+    ColumnValue MinIfs(ColumnMatrix minRange, params ColumnValue[] criteria);
+
+    /// <summary>LARGE - the k-th largest value of a range.</summary>
+    ColumnValue Large(ColumnMatrix array, ColumnValue k);
+
+    /// <summary>SMALL - the k-th smallest value of a range.</summary>
+    ColumnValue Small(ColumnMatrix array, ColumnValue k);
+
+    /// <summary>RANK - rank of a number within a range.</summary>
+    ColumnValue Rank(ColumnValue number, ColumnMatrix reference);
+
+    /// <summary>RANK - rank of a number within a range, ascending when <paramref name="order" /> is non zero.</summary>
+    ColumnValue Rank(ColumnValue number, ColumnMatrix reference, ColumnValue order);
+
+    /// <summary>RANK.EQ - rank of a number, ties sharing the highest rank.</summary>
+    [ExcelFunctionName("RANK.EQ", Future = true)]
+    ColumnValue RankEq(ColumnValue number, ColumnMatrix reference, ColumnValue order);
+
+    /// <summary>RANK.AVG - rank of a number, ties sharing the average rank.</summary>
+    [ExcelFunctionName("RANK.AVG", Future = true)]
+    ColumnValue RankAvg(ColumnValue number, ColumnMatrix reference, ColumnValue order);
+
+    /// <summary>PERCENTRANK - percentage rank of a value within a range.</summary>
+    [ExcelFunctionName("PERCENTRANK")]
+    ColumnValue PercentRank(ColumnMatrix array, ColumnValue x);
+
+    /// <summary>PERCENTILE - the k-th percentile of a range.</summary>
+    ColumnValue Percentile(ColumnMatrix array, ColumnValue k);
+
+    /// <summary>PERCENTILE.INC - percentile, inclusive of 0 and 1.</summary>
+    [ExcelFunctionName("PERCENTILE.INC", Future = true)]
+    ColumnValue PercentileInc(ColumnMatrix array, ColumnValue k);
+
+    /// <summary>PERCENTILE.EXC - percentile, exclusive of 0 and 1.</summary>
+    [ExcelFunctionName("PERCENTILE.EXC", Future = true)]
+    ColumnValue PercentileExc(ColumnMatrix array, ColumnValue k);
+
+    /// <summary>QUARTILE - the quartile of a range.</summary>
+    ColumnValue Quartile(ColumnMatrix array, ColumnValue quart);
+
+    /// <summary>QUARTILE.INC - quartile, inclusive of 0 and 1.</summary>
+    [ExcelFunctionName("QUARTILE.INC", Future = true)]
+    ColumnValue QuartileInc(ColumnMatrix array, ColumnValue quart);
+
+    /// <summary>QUARTILE.EXC - quartile, exclusive of 0 and 1.</summary>
+    [ExcelFunctionName("QUARTILE.EXC", Future = true)]
+    ColumnValue QuartileExc(ColumnMatrix array, ColumnValue quart);
+
+    // ---- central tendency and spread ----
+
+    /// <summary>MEDIAN - median of its arguments.</summary>
+    ColumnValue Median(params ColumnValue[] values);
+
+    /// <summary>MODE - most frequent value.</summary>
+    ColumnValue Mode(params ColumnValue[] values);
+
+    /// <summary>MODE.SNGL - most frequent value.</summary>
+    [ExcelFunctionName("MODE.SNGL", Future = true)]
+    ColumnValue ModeSngl(params ColumnValue[] values);
+
+    /// <summary>MODE.MULT - the most frequent values, as an array.</summary>
+    [ExcelFunctionName("MODE.MULT", Future = true)]
+    ColumnValue ModeMult(params ColumnValue[] values);
+
+    /// <summary>GEOMEAN - geometric mean.</summary>
+    [ExcelFunctionName("GEOMEAN")]
+    ColumnValue GeoMean(params ColumnValue[] values);
+
+    /// <summary>HARMEAN - harmonic mean.</summary>
+    [ExcelFunctionName("HARMEAN")]
+    ColumnValue HarMean(params ColumnValue[] values);
+
+    /// <summary>TRIMMEAN - mean of the interior of a data set.</summary>
+    [ExcelFunctionName("TRIMMEAN")]
+    ColumnValue TrimMean(ColumnMatrix array, ColumnValue percent);
+
+    /// <summary>AVEDEV - average of the absolute deviations from the mean.</summary>
+    [ExcelFunctionName("AVEDEV")]
+    ColumnValue AveDev(params ColumnValue[] values);
+
+    /// <summary>DEVSQ - sum of the squares of the deviations from the mean.</summary>
+    [ExcelFunctionName("DEVSQ")]
+    ColumnValue DevSq(params ColumnValue[] values);
+
+    /// <summary>STDEV - sample standard deviation.</summary>
+    [ExcelFunctionName("STDEV")]
+    ColumnValue StDev(params ColumnValue[] values);
+
+    /// <summary>STDEV.S - sample standard deviation.</summary>
+    [ExcelFunctionName("STDEV.S", Future = true)]
+    ColumnValue StDevS(params ColumnValue[] values);
+
+    /// <summary>STDEV.P - population standard deviation.</summary>
+    [ExcelFunctionName("STDEV.P", Future = true)]
+    ColumnValue StDevP(params ColumnValue[] values);
+
+    /// <summary>STDEVA - sample standard deviation, counting text and logical values.</summary>
+    [ExcelFunctionName("STDEVA")]
+    ColumnValue StDevA(params ColumnValue[] values);
+
+    /// <summary>STDEVPA - population standard deviation, counting text and logical values.</summary>
+    [ExcelFunctionName("STDEVPA")]
+    ColumnValue StDevPA(params ColumnValue[] values);
+
+    /// <summary>VAR - sample variance.</summary>
+    [ExcelFunctionName("VAR")]
+    ColumnValue Var(params ColumnValue[] values);
+
+    /// <summary>VAR.S - sample variance.</summary>
+    [ExcelFunctionName("VAR.S", Future = true)]
+    ColumnValue VarS(params ColumnValue[] values);
+
+    /// <summary>VAR.P - population variance.</summary>
+    [ExcelFunctionName("VAR.P", Future = true)]
+    ColumnValue VarP(params ColumnValue[] values);
+
+    /// <summary>VARA - sample variance, counting text and logical values.</summary>
+    [ExcelFunctionName("VARA")]
+    ColumnValue VarA(params ColumnValue[] values);
+
+    /// <summary>VARPA - population variance, counting text and logical values.</summary>
+    [ExcelFunctionName("VARPA")]
+    ColumnValue VarPA(params ColumnValue[] values);
+
+    /// <summary>SKEW - skewness of a distribution.</summary>
+    ColumnValue Skew(params ColumnValue[] values);
+
+    /// <summary>KURT - kurtosis of a data set.</summary>
+    [ExcelFunctionName("KURT")]
+    ColumnValue Kurt(params ColumnValue[] values);
+
+    /// <summary>STANDARDIZE - normalized value of a distribution.</summary>
+    ColumnValue Standardize(ColumnValue x, ColumnValue mean, ColumnValue standardDev);
+
+    /// <summary>FREQUENCY - frequency distribution of a data set.</summary>
+    ColumnValue Frequency(ColumnMatrix dataArray, ColumnMatrix binsArray);
+
+    // ---- relationships and forecasting ----
+
+    /// <summary>CORREL - correlation coefficient of two data sets.</summary>
+    [ExcelFunctionName("CORREL")]
+    ColumnValue Correl(ColumnMatrix array1, ColumnMatrix array2);
+
+    /// <summary>COVARIANCE.P - population covariance of two data sets.</summary>
+    [ExcelFunctionName("COVARIANCE.P", Future = true)]
+    ColumnValue CovarianceP(ColumnMatrix array1, ColumnMatrix array2);
+
+    /// <summary>COVARIANCE.S - sample covariance of two data sets.</summary>
+    [ExcelFunctionName("COVARIANCE.S", Future = true)]
+    ColumnValue CovarianceS(ColumnMatrix array1, ColumnMatrix array2);
+
+    /// <summary>SLOPE - slope of the linear regression line.</summary>
+    ColumnValue Slope(ColumnMatrix knownYs, ColumnMatrix knownXs);
+
+    /// <summary>INTERCEPT - intercept of the linear regression line.</summary>
+    ColumnValue Intercept(ColumnMatrix knownYs, ColumnMatrix knownXs);
+
+    /// <summary>RSQ - square of the Pearson correlation coefficient.</summary>
+    [ExcelFunctionName("RSQ")]
+    ColumnValue Rsq(ColumnMatrix knownYs, ColumnMatrix knownXs);
+
+    /// <summary>STEYX - standard error of the predicted y values.</summary>
+    [ExcelFunctionName("STEYX")]
+    ColumnValue SteyX(ColumnMatrix knownYs, ColumnMatrix knownXs);
+
+    /// <summary>FORECAST.LINEAR - predicts a value along a linear trend.</summary>
+    [ExcelFunctionName("FORECAST.LINEAR", Future = true)]
+    ColumnValue ForecastLinear(ColumnValue x, ColumnMatrix knownYs, ColumnMatrix knownXs);
+
+    /// <summary>FORECAST - predicts a value along a linear trend.</summary>
+    ColumnValue Forecast(ColumnValue x, ColumnMatrix knownYs, ColumnMatrix knownXs);
+
+    /// <summary>TREND - values along a linear trend.</summary>
+    ColumnValue Trend(ColumnMatrix knownYs, ColumnMatrix knownXs, ColumnMatrix newXs);
+
+    /// <summary>GROWTH - values along an exponential trend.</summary>
+    ColumnValue Growth(ColumnMatrix knownYs, ColumnMatrix knownXs, ColumnMatrix newXs);
+
+    /// <summary>LINEST - parameters of a linear trend.</summary>
+    [ExcelFunctionName("LINEST")]
+    ColumnValue LinEst(ColumnMatrix knownYs, ColumnMatrix knownXs);
+
+    /// <summary>LOGEST - parameters of an exponential trend.</summary>
+    [ExcelFunctionName("LOGEST")]
+    ColumnValue LogEst(ColumnMatrix knownYs, ColumnMatrix knownXs);
+
+    // ---- distributions ----
+
+    /// <summary>PERMUT - number of permutations without repetition.</summary>
+    ColumnValue Permut(ColumnValue number, ColumnValue numberChosen);
+
+    /// <summary>PERMUTATIONA - number of permutations with repetition.</summary>
+    [ExcelFunctionName("PERMUTATIONA", Future = true)]
+    ColumnValue PermutationA(ColumnValue number, ColumnValue numberChosen);
+
+    /// <summary>NORM.DIST - normal cumulative distribution.</summary>
+    [ExcelFunctionName("NORM.DIST", Future = true)]
+    ColumnValue NormDist(ColumnValue x, ColumnValue mean, ColumnValue standardDev, ColumnValue cumulative);
+
+    /// <summary>NORM.INV - inverse of the normal cumulative distribution.</summary>
+    [ExcelFunctionName("NORM.INV", Future = true)]
+    ColumnValue NormInv(ColumnValue probability, ColumnValue mean, ColumnValue standardDev);
+
+    /// <summary>NORM.S.DIST - standard normal cumulative distribution.</summary>
+    [ExcelFunctionName("NORM.S.DIST", Future = true)]
+    ColumnValue NormSDist(ColumnValue z, ColumnValue cumulative);
+
+    /// <summary>NORM.S.INV - inverse of the standard normal cumulative distribution.</summary>
+    [ExcelFunctionName("NORM.S.INV", Future = true)]
+    ColumnValue NormSInv(ColumnValue probability);
+
+    /// <summary>BINOM.DIST - binomial distribution probability.</summary>
+    [ExcelFunctionName("BINOM.DIST", Future = true)]
+    ColumnValue BinomDist(ColumnValue numberS, ColumnValue trials, ColumnValue probabilityS, ColumnValue cumulative);
+
+    /// <summary>POISSON.DIST - Poisson distribution probability.</summary>
+    [ExcelFunctionName("POISSON.DIST", Future = true)]
+    ColumnValue PoissonDist(ColumnValue x, ColumnValue mean, ColumnValue cumulative);
+
+    /// <summary>EXPON.DIST - exponential distribution probability.</summary>
+    [ExcelFunctionName("EXPON.DIST", Future = true)]
+    ColumnValue ExponDist(ColumnValue x, ColumnValue lambda, ColumnValue cumulative);
+
+    /// <summary>T.DIST - Student's t-distribution.</summary>
+    [ExcelFunctionName("T.DIST", Future = true)]
+    ColumnValue TDist(ColumnValue x, ColumnValue degFreedom, ColumnValue cumulative);
+
+    /// <summary>T.INV - inverse of Student's t-distribution.</summary>
+    [ExcelFunctionName("T.INV", Future = true)]
+    ColumnValue TInv(ColumnValue probability, ColumnValue degFreedom);
+
+    /// <summary>T.TEST - probability associated with a Student's t-test.</summary>
+    [ExcelFunctionName("T.TEST", Future = true)]
+    ColumnValue TTest(ColumnMatrix array1, ColumnMatrix array2, ColumnValue tails, ColumnValue type);
+
+    /// <summary>CHISQ.TEST - test for independence.</summary>
+    [ExcelFunctionName("CHISQ.TEST", Future = true)]
+    ColumnValue ChiSqTest(ColumnMatrix actualRange, ColumnMatrix expectedRange);
+
+    /// <summary>CONFIDENCE.NORM - confidence interval for a population mean.</summary>
+    [ExcelFunctionName("CONFIDENCE.NORM", Future = true)]
+    ColumnValue ConfidenceNorm(ColumnValue alpha, ColumnValue standardDev, ColumnValue size);
+
+    /// <summary>CONFIDENCE.T - confidence interval using a Student's t-distribution.</summary>
+    [ExcelFunctionName("CONFIDENCE.T", Future = true)]
+    ColumnValue ConfidenceT(ColumnValue alpha, ColumnValue standardDev, ColumnValue size);
+
+    /// <summary>PROB - probability that values are between two limits.</summary>
+    ColumnValue Prob(ColumnMatrix xRange, ColumnMatrix probRange, ColumnValue lowerLimit, ColumnValue upperLimit);
 }

--- a/Chsword.Excel2Object/Functions/ITextFunction.cs
+++ b/Chsword.Excel2Object/Functions/ITextFunction.cs
@@ -1,31 +1,170 @@
 ﻿namespace Chsword.Excel2Object.Functions;
 
 /// <summary>
-/// Interface for text functions used in Excel to object conversion.
+///     Excel text functions. See <see cref="IExcelFunction" /> for how these are translated.
 /// </summary>
-public interface ITextFunction
+public interface ITextFunction : IExcelFunction
 {
-    /// <summary>
-    /// Converts a string to ASCII values.
-    /// </summary>
-    /// <param name="str">The string to convert.</param>
-    /// <returns>A <see cref="ColumnValue"/> representing the ASCII values of the string.</returns>
-    ColumnValue Asc(ColumnValue str);
+    // ---- pieces of a string ----
 
-    /// <summary>
-    /// Finds one text string within another, starting at a specified position.
-    /// </summary>
-    /// <param name="findText">The text to find.</param>
-    /// <param name="withinText">The text to search within.</param>
-    /// <param name="startNum">The position to start the search from.</param>
-    /// <returns>A <see cref="ColumnValue"/> representing the position of the found text.</returns>
+    /// <summary>LEFT - the first character of a string.</summary>
+    ColumnValue Left(ColumnValue text);
+
+    /// <summary>LEFT - the first characters of a string.</summary>
+    ColumnValue Left(ColumnValue text, ColumnValue numChars);
+
+    /// <summary>RIGHT - the last character of a string.</summary>
+    ColumnValue Right(ColumnValue text);
+
+    /// <summary>RIGHT - the last characters of a string.</summary>
+    ColumnValue Right(ColumnValue text, ColumnValue numChars);
+
+    /// <summary>MID - the characters of a string from a position on.</summary>
+    ColumnValue Mid(ColumnValue text, ColumnValue startNum, ColumnValue numChars);
+
+    /// <summary>LEN - the number of characters of a string.</summary>
+    [ExcelFunctionName("LEN")]
+    ColumnValue Len(ColumnValue text);
+
+    /// <summary>LEFTB - the first bytes of a string, double byte characters counting as two.</summary>
+    [ExcelFunctionName("LEFTB")]
+    ColumnValue LeftB(ColumnValue text, ColumnValue numBytes);
+
+    /// <summary>RIGHTB - the last bytes of a string, double byte characters counting as two.</summary>
+    [ExcelFunctionName("RIGHTB")]
+    ColumnValue RightB(ColumnValue text, ColumnValue numBytes);
+
+    /// <summary>MIDB - the bytes of a string from a position on.</summary>
+    [ExcelFunctionName("MIDB")]
+    ColumnValue MidB(ColumnValue text, ColumnValue startNum, ColumnValue numBytes);
+
+    /// <summary>LENB - the number of bytes of a string, double byte characters counting as two.</summary>
+    [ExcelFunctionName("LENB")]
+    ColumnValue LenB(ColumnValue text);
+
+    /// <summary>TEXTBEFORE - the text before a delimiter.</summary>
+    [ExcelFunctionName("TEXTBEFORE", Future = true)]
+    ColumnValue TextBefore(ColumnValue text, ColumnValue delimiter);
+
+    /// <summary>TEXTAFTER - the text after a delimiter.</summary>
+    [ExcelFunctionName("TEXTAFTER", Future = true)]
+    ColumnValue TextAfter(ColumnValue text, ColumnValue delimiter);
+
+    /// <summary>TEXTSPLIT - splits a string by a column delimiter.</summary>
+    [ExcelFunctionName("TEXTSPLIT", Future = true)]
+    ColumnValue TextSplit(ColumnValue text, ColumnValue colDelimiter);
+
+    // ---- searching and editing ----
+
+    /// <summary>FIND - the position of one string inside another, case sensitive.</summary>
+    ColumnValue Find(ColumnValue findText, ColumnValue withinText);
+
+    /// <summary>FIND - the position of one string inside another, from a start position.</summary>
     ColumnValue Find(ColumnValue findText, ColumnValue withinText, int startNum);
 
-    /// <summary>
-    /// Finds one text string within another.
-    /// </summary>
-    /// <param name="findText">The text to find.</param>
-    /// <param name="withinText">The text to search within.</param>
-    /// <returns>A <see cref="ColumnValue"/> representing the position of the found text.</returns>
-    ColumnValue Find(ColumnValue findText, ColumnValue withinText);
+    /// <summary>FINDB - as FIND, counting double byte characters as two.</summary>
+    [ExcelFunctionName("FINDB")]
+    ColumnValue FindB(ColumnValue findText, ColumnValue withinText);
+
+    /// <summary>SEARCH - the position of one string inside another, ignoring case and allowing wildcards.</summary>
+    ColumnValue Search(ColumnValue findText, ColumnValue withinText);
+
+    /// <summary>SEARCH - as above, from a start position.</summary>
+    ColumnValue Search(ColumnValue findText, ColumnValue withinText, ColumnValue startNum);
+
+    /// <summary>SEARCHB - as SEARCH, counting double byte characters as two.</summary>
+    [ExcelFunctionName("SEARCHB")]
+    ColumnValue SearchB(ColumnValue findText, ColumnValue withinText);
+
+    /// <summary>SUBSTITUTE - replaces every occurrence of a string with another.</summary>
+    ColumnValue Substitute(ColumnValue text, ColumnValue oldText, ColumnValue newText);
+
+    /// <summary>SUBSTITUTE - replaces the n-th occurrence of a string with another.</summary>
+    ColumnValue Substitute(ColumnValue text, ColumnValue oldText, ColumnValue newText, ColumnValue instanceNum);
+
+    /// <summary>REPLACE - replaces part of a string, by position.</summary>
+    ColumnValue Replace(ColumnValue oldText, ColumnValue startNum, ColumnValue numChars, ColumnValue newText);
+
+    /// <summary>REPT - repeats a string the given number of times.</summary>
+    [ExcelFunctionName("REPT")]
+    ColumnValue Rept(ColumnValue text, ColumnValue numberTimes);
+
+    /// <summary>TRIM - removes the extra spaces of a string.</summary>
+    ColumnValue Trim(ColumnValue text);
+
+    /// <summary>CLEAN - removes the non printable characters of a string.</summary>
+    ColumnValue Clean(ColumnValue text);
+
+    // ---- case and comparison ----
+
+    /// <summary>UPPER - converts a string to upper case.</summary>
+    ColumnValue Upper(ColumnValue text);
+
+    /// <summary>LOWER - converts a string to lower case.</summary>
+    ColumnValue Lower(ColumnValue text);
+
+    /// <summary>PROPER - capitalizes the first letter of every word.</summary>
+    ColumnValue Proper(ColumnValue text);
+
+    /// <summary>EXACT - TRUE when two strings are exactly the same.</summary>
+    ColumnValue Exact(ColumnValue text1, ColumnValue text2);
+
+    // ---- joining ----
+
+    /// <summary>CONCAT - joins its arguments into one string.</summary>
+    [ExcelFunctionName("CONCAT", Future = true)]
+    ColumnValue Concat(params ColumnValue[] values);
+
+    /// <summary>CONCATENATE - joins its arguments into one string.</summary>
+    [ExcelFunctionName("CONCATENATE")]
+    ColumnValue Concatenate(params ColumnValue[] values);
+
+    /// <summary>TEXTJOIN - joins its arguments with a delimiter.</summary>
+    [ExcelFunctionName("TEXTJOIN", Future = true)]
+    ColumnValue TextJoin(ColumnValue delimiter, ColumnValue ignoreEmpty, params ColumnValue[] values);
+
+    // ---- conversion ----
+
+    /// <summary>TEXT - formats a number with a format code, e.g. <c>"0.00"</c>.</summary>
+    [ExcelFunctionName("TEXT")]
+    ColumnValue Text(ColumnValue val, ColumnValue formatText);
+
+    /// <summary>VALUE - converts a string to a number.</summary>
+    ColumnValue Value(ColumnValue text);
+
+    /// <summary>NUMBERVALUE - converts a string to a number, with explicit separators.</summary>
+    [ExcelFunctionName("NUMBERVALUE", Future = true)]
+    ColumnValue NumberValue(ColumnValue text, ColumnValue decimalSeparator, ColumnValue groupSeparator);
+
+    /// <summary>FIXED - formats a number as text with a fixed number of decimals.</summary>
+    ColumnValue Fixed(ColumnValue number, ColumnValue decimals);
+
+    /// <summary>DOLLAR - formats a number as text in the currency format.</summary>
+    ColumnValue Dollar(ColumnValue number, ColumnValue decimals);
+
+    /// <summary>CHAR - the character of a character code.</summary>
+    [ExcelFunctionName("CHAR")]
+    ColumnValue Char(ColumnValue number);
+
+    /// <summary>CODE - the character code of the first character of a string.</summary>
+    ColumnValue Code(ColumnValue text);
+
+    /// <summary>UNICHAR - the character of a Unicode code point.</summary>
+    [ExcelFunctionName("UNICHAR", Future = true)]
+    ColumnValue UniChar(ColumnValue number);
+
+    /// <summary>UNICODE - the Unicode code point of the first character of a string.</summary>
+    [ExcelFunctionName("UNICODE", Future = true)]
+    ColumnValue Unicode(ColumnValue text);
+
+    /// <summary>ASC - converts full width characters to half width ones.</summary>
+    ColumnValue Asc(ColumnValue str);
+
+    /// <summary>WIDECHAR - converts half width characters to full width ones.</summary>
+    [ExcelFunctionName("WIDECHAR")]
+    ColumnValue WideChar(ColumnValue text);
+
+    /// <summary>T - the argument when it is text, an empty string otherwise.</summary>
+    [ExcelFunctionName("T")]
+    ColumnValue T(ColumnValue val);
 }

--- a/Chsword.Excel2Object/Internal/ExpressionConvert.cs
+++ b/Chsword.Excel2Object/Internal/ExpressionConvert.cs
@@ -1,22 +1,13 @@
-﻿using System.Linq.Expressions;
+﻿using System.Globalization;
+using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Chsword.Excel2Object.Functions;
 
 namespace Chsword.Excel2Object.Internal;
 
 internal class ExpressionConvert
 {
-    private static readonly Type[] CallMethodTypes =
-    {
-        typeof(IMathFunction),
-        typeof(IStatisticsFunction),
-        typeof(IConditionFunction),
-        typeof(IReferenceFunction),
-        typeof(IDateTimeFunction),
-        typeof(ITextFunction),
-        typeof(IAllFunction)
-    };
-
     public ExpressionConvert(string[] columns, int rowIndex)
         : this(columns, rowIndex, null)
     {
@@ -35,6 +26,13 @@ internal class ExpressionConvert
         SheetColumnsResolver = sheetColumnsResolver;
     }
 
+    /// <summary>
+    ///     Compiled evaluators for the sheet-independent sub-expressions of a formula, keyed by the node
+    ///     they came from. A formula column holds one expression tree and is converted once per row, so
+    ///     without this the same lambda would be compiled again for every row of the sheet.
+    /// </summary>
+    private static readonly ConditionalWeakTable<Expression, Func<object?>> Evaluators = new();
+
     private static Dictionary<ExpressionType, string> BinarySymbolDictionary { get; } =
         new()
         {
@@ -48,8 +46,18 @@ internal class ExpressionConvert
             [ExpressionType.LessThan] = "<",
             [ExpressionType.GreaterThanOrEqual] = ">=",
             [ExpressionType.LessThanOrEqual] = "<=",
-            [ExpressionType.And] = "&"
+            [ExpressionType.And] = "&",
+            [ExpressionType.ExclusiveOr] = "^"
         };
+
+    /// <summary>
+    ///     <see cref="System.Math" /> methods that Excel spells the same way, only in upper case.
+    /// </summary>
+    private static HashSet<string> DirectMathMethods { get; } = new(StringComparer.Ordinal)
+    {
+        "Abs", "Sqrt", "Exp", "Sign", "Sin", "Cos", "Tan", "Asin", "Acos", "Atan",
+        "Sinh", "Cosh", "Tanh", "Max", "Min", "Log10"
+    };
 
     private string[] Columns { get; }
     private int RowIndex { get; }
@@ -79,13 +87,60 @@ internal class ExpressionConvert
 
     private static string ConvertConstant(Expression expression)
     {
-        var exp = expression as ConstantExpression;
-        return (exp?.Type == typeof(bool) ? exp.ToString().ToUpper() : exp?.ToString()) ?? string.Empty;
+        return expression is ConstantExpression exp ? FormatValue(exp.Value) : string.Empty;
+    }
+
+    /// <summary>
+    ///     Writes a .NET value as formula text. Numbers are always written with an invariant decimal
+    ///     point, since a formula that carries a locale's comma would not parse in Excel.
+    /// </summary>
+    private static string FormatValue(object? value)
+    {
+        switch (value)
+        {
+            case null:
+                return string.Empty;
+            case bool b:
+                return b ? "TRUE" : "FALSE";
+            case string s:
+                return QuoteText(s);
+            case char ch:
+                return QuoteText(ch.ToString());
+            case DateTime dt:
+                return FormatDateTime(dt);
+            case Enum e:
+                return System.Convert.ToInt64(e, CultureInfo.InvariantCulture)
+                    .ToString(CultureInfo.InvariantCulture);
+            case IFormattable formattable:
+                return formattable.ToString(null, CultureInfo.InvariantCulture);
+            default:
+                return value.ToString() ?? string.Empty;
+        }
+    }
+
+    /// <summary>Excel text literals are double quoted, and an embedded quote is doubled.</summary>
+    private static string QuoteText(string text)
+    {
+        return "\"" + text.Replace("\"", "\"\"") + "\"";
+    }
+
+    private static string FormatDateTime(DateTime value)
+    {
+        var date = $"DATE({value.Year},{value.Month},{value.Day})";
+        if (value.TimeOfDay == TimeSpan.Zero) return date;
+        var time = $"TIME({value.Hour},{value.Minute},{value.Second})";
+        // TIME only takes whole seconds, so anything finer is added as its fraction of a day
+        var subSecond = value.Ticks % TimeSpan.TicksPerSecond;
+        if (subSecond == 0) return $"{date}+{time}";
+        var fraction = (double) subSecond / TimeSpan.TicksPerDay;
+        return $"{date}+{time}+{fraction.ToString("R", CultureInfo.InvariantCulture)}";
     }
 
     private string ConvertBinaryExpression(Expression expression)
     {
-        if (!(expression is BinaryExpression binary)) return "null";
+        if (expression is not BinaryExpression binary) return "null";
+        if (FunctionOfBinary(binary) is { } function)
+            return $"{function}({InternalConvert(binary.Left)},{InternalConvert(binary.Right)})";
         var symbol = BinarySymbol(binary);
         var precedence = Precedence(binary);
         var left = InternalConvert(binary.Left);
@@ -96,10 +151,43 @@ internal class ExpressionConvert
         if (Precedence(binary.Left) < precedence) left = $"({left})";
         var rightPrecedence = Precedence(binary.Right);
         if (rightPrecedence < precedence ||
-            (rightPrecedence == precedence && binary.NodeType is ExpressionType.Subtract or ExpressionType.Divide))
+            (rightPrecedence == precedence && binary.NodeType is ExpressionType.Subtract
+                 or ExpressionType.Divide or ExpressionType.ExclusiveOr))
             right = $"({right})";
 
         return $"{left}{symbol}{right}";
+    }
+
+    /// <summary>
+    ///     The Excel function a binary node is written as, for the operators Excel has no symbol for;
+    ///     null when the node is written with an operator instead.
+    /// </summary>
+    private static string? FunctionOfBinary(BinaryExpression binary)
+    {
+        // a lifted operator on nullable operands is typed bool?/int?, so compare the underlying type
+        var type = Nullable.GetUnderlyingType(binary.Type) ?? binary.Type;
+        var isBoolean = type == typeof(bool);
+        var isInteger = type == typeof(int) || type == typeof(long) ||
+                        type == typeof(short) || type == typeof(byte) ||
+                        type == typeof(uint) || type == typeof(ulong);
+        switch (binary.NodeType)
+        {
+            case ExpressionType.Modulo:
+                return "MOD";
+            case ExpressionType.AndAlso:
+                return "AND";
+            case ExpressionType.OrElse:
+                return "OR";
+            case ExpressionType.And:
+                return isBoolean ? "AND" : isInteger ? Future("BITAND") : null;
+            case ExpressionType.Or:
+                return isInteger ? Future("BITOR") : "OR";
+            case ExpressionType.ExclusiveOr:
+                // ^ on a ColumnValue is Excel's power operator; on bools and integers it really is a xor
+                return isBoolean ? Future("XOR") : isInteger ? Future("BITXOR") : null;
+            default:
+                return null;
+        }
     }
 
     private static string BinarySymbol(BinaryExpression binary)
@@ -117,11 +205,14 @@ internal class ExpressionConvert
     /// </summary>
     private static int Precedence(Expression expression)
     {
-        while (expression is UnaryExpression { NodeType: ExpressionType.Convert } convert)
+        while (expression is UnaryExpression {NodeType: ExpressionType.Convert} convert)
             expression = convert.Operand;
         if (expression is not BinaryExpression binary) return int.MaxValue;
+        if (FunctionOfBinary(binary) != null) return int.MaxValue;
         switch (BinarySymbol(binary))
         {
+            case "^":
+                return 5;
             case "*":
             case "/":
                 return 4;
@@ -137,40 +228,190 @@ internal class ExpressionConvert
 
     private string ConvertCall(Expression expression)
     {
-        if (!(expression is MethodCallExpression exp) || exp.Object == null) return "null";
-        if (exp.Method.Name == "get_Item" &&
-            (exp.Object.Type == typeof(ColumnCellDictionary)
-             || exp.Object.Type == typeof(Dictionary<string, ColumnValue>)
-            )
-           )
-            return exp.Arguments.Count == 2
-                ? $"{GetColumn(exp.Arguments[0])}{InternalConvert(exp.Arguments[1])}"
-                : $"{GetColumn(exp.Arguments[0])}{RowIndex + 1}";
-
-        if (exp.Object.Type == typeof(ColumnCellDictionary) &&
-            exp.Method.Name == nameof(ColumnCellDictionary.Matrix))
-            return
-                $"{GetColumn(exp.Arguments[0])}{exp.Arguments[1]}:{GetColumn(exp.Arguments[2])}{exp.Arguments[3]}";
-
-        if (exp.Object.Type == typeof(ColumnCellDictionary) &&
-            exp.Method.Name == nameof(ColumnCellDictionary.Columns))
-            return $"{GetColumn(exp.Arguments[0])}:{GetColumn(exp.Arguments[1])}";
-
-        if (exp.Object.Type == typeof(SheetCellDictionary))
-            return ConvertSheetCall(exp);
-
-        if (exp.Method.DeclaringType == typeof(DateTime))
+        if (expression is not MethodCallExpression exp) return "null";
+        if (exp.Object != null)
         {
-            if (exp.Method.Name == nameof(DateTime.AddMonths))
-                return $"EDATE({InternalConvert(exp.Object)},{InternalConvert(exp.Arguments[0])})";
+            if (exp.Method.Name == "get_Item" &&
+                (exp.Object.Type == typeof(ColumnCellDictionary)
+                 || exp.Object.Type == typeof(Dictionary<string, ColumnValue>)
+                )
+               )
+                return exp.Arguments.Count == 2
+                    ? $"{GetColumn(exp.Arguments[0])}{InternalConvert(exp.Arguments[1])}"
+                    : $"{GetColumn(exp.Arguments[0])}{RowIndex + 1}";
+
+            if (exp.Object.Type == typeof(ColumnCellDictionary) &&
+                exp.Method.Name == nameof(ColumnCellDictionary.Matrix))
+                return
+                    $"{GetColumn(exp.Arguments[0])}{ConvertRowNumber(exp.Arguments[1])}:{GetColumn(exp.Arguments[2])}{ConvertRowNumber(exp.Arguments[3])}";
+
+            if (exp.Object.Type == typeof(ColumnCellDictionary) &&
+                exp.Method.Name == nameof(ColumnCellDictionary.Columns))
+                return $"{GetColumn(exp.Arguments[0])}:{GetColumn(exp.Arguments[1])}";
+
+            if (exp.Object.Type == typeof(SheetCellDictionary))
+                return ConvertSheetCall(exp);
         }
-        else if (CallMethodTypes.Contains(exp.Method.DeclaringType))
-        {
-            return
-                $"{exp.Method.Name.ToUpper()}({string.Join(",", exp.Arguments.Select(c => InternalConvert(c)))})";
-        }
+
+        if (IsExcelFunction(exp.Method.DeclaringType))
+            return $"{ExcelFunctionName(exp.Method)}({JoinArguments(exp.Arguments)})";
+
+        if (exp.Method.DeclaringType == typeof(DateTime) && ConvertDateTimeCall(exp) is { } dateCall)
+            return dateCall;
+
+        if (exp.Method.DeclaringType == typeof(string) && ConvertStringCall(exp) is { } stringCall)
+            return stringCall;
+
+        if (exp.Method.DeclaringType == typeof(System.Math) && ConvertMathCall(exp) is { } mathCall)
+            return mathCall;
+
+        // A call that uses nothing from the sheet is just a value, e.g. a helper the formula was built with.
+        if (TryEvaluate(exp, out var value)) return FormatValue(value);
 
         return $"unspport call type={exp.Method.DeclaringType} name={exp.Method.Name}";
+    }
+
+    /// <summary>
+    ///     The name a function interface method is written under, from its attribute or its method name.
+    ///     Functions Excel gained after 2007 carry the <c>_xlfn.</c> prefix the file format stores them with.
+    /// </summary>
+    private static string ExcelFunctionName(MethodInfo method)
+    {
+        var attribute = method.GetCustomAttribute<ExcelFunctionNameAttribute>();
+        return attribute?.StoredName ?? method.Name.ToUpperInvariant();
+    }
+
+    /// <summary>A function Excel gained after 2007, spelled the way the file format stores it.</summary>
+    private static string Future(string name)
+    {
+        return ExcelFunctionNameAttribute.FuturePrefix + name;
+    }
+
+    private static bool IsExcelFunction(Type? declaringType)
+    {
+        return declaringType != null && typeof(IExcelFunction).IsAssignableFrom(declaringType);
+    }
+
+    private string JoinArguments(IEnumerable<Expression> arguments)
+    {
+        return string.Join(",", arguments.Select(c => InternalConvert(c)));
+    }
+
+    private string? ConvertDateTimeCall(MethodCallExpression exp)
+    {
+        if (exp.Object == null) return null;
+        var target = InternalConvert(exp.Object);
+        switch (exp.Method.Name)
+        {
+            case nameof(DateTime.AddMonths):
+                return $"EDATE({target},{InternalConvert(exp.Arguments[0])})";
+            case nameof(DateTime.AddYears):
+                return $"EDATE({target},({InternalConvert(exp.Arguments[0])})*12)";
+            case nameof(DateTime.AddDays):
+                // a date plus a number of days; parenthesized so it composes like any other operand
+                return $"({target}+{InternalConvert(exp.Arguments[0])})";
+            default:
+                return null;
+        }
+    }
+
+    private string? ConvertStringCall(MethodCallExpression exp)
+    {
+        var args = exp.Arguments;
+        if (exp.Object == null)
+            switch (exp.Method.Name)
+            {
+                case nameof(string.Concat):
+                    return $"{Future("CONCAT")}({JoinArguments(args)})";
+                case nameof(string.Join):
+                    return
+                        // ignore_empty FALSE: string.Join keeps empty entries
+                        $"{Future("TEXTJOIN")}({InternalConvert(args[0])},FALSE,{JoinArguments(args.Skip(1))})";
+                case nameof(string.IsNullOrEmpty):
+                    return $"({InternalConvert(args[0])}=\"\")";
+                // IsNullOrWhiteSpace has no equivalent: it counts tabs and the Unicode spaces, while
+                // Excel's TRIM only strips the ASCII space.
+                default:
+                    return null;
+            }
+
+        // Every case below pins its argument count, which is what keeps the overloads Excel cannot
+        // express - the ones taking a StringComparison, a CultureInfo, a start index or a char[] -
+        // off the translated path. Dropping such an argument would change what the formula means.
+        // Trim() is absent for the same reason: Excel's TRIM also collapses runs of spaces inside
+        // the text, so it does not mean what .NET's Trim() means.
+        var target = InternalConvert(exp.Object);
+        switch (exp.Method.Name)
+        {
+            case nameof(string.ToUpper) when args.Count == 0:
+                return $"UPPER({target})";
+            case nameof(string.ToLower) when args.Count == 0:
+                return $"LOWER({target})";
+            case nameof(string.Substring) when args.Count == 1:
+                return $"MID({target},{OneBased(args[0])},LEN({target}))";
+            case nameof(string.Substring) when args.Count == 2:
+                return $"MID({target},{OneBased(args[0])},{InternalConvert(args[1])})";
+            case nameof(string.Replace) when args.Count == 2:
+                return $"SUBSTITUTE({target},{InternalConvert(args[0])},{InternalConvert(args[1])})";
+            case nameof(string.Contains) when args.Count == 1:
+                // FIND, not SEARCH: the .NET methods are case sensitive and take no wildcards
+                return $"ISNUMBER(FIND({InternalConvert(args[0])},{target}))";
+            case nameof(string.StartsWith) when args.Count == 1:
+                // EXACT, not =: Excel's = ignores case
+                return $"EXACT(LEFT({target},LEN({InternalConvert(args[0])})),{InternalConvert(args[0])})";
+            case nameof(string.EndsWith) when args.Count == 1:
+                return $"EXACT(RIGHT({target},LEN({InternalConvert(args[0])})),{InternalConvert(args[0])})";
+            case nameof(string.IndexOf) when args.Count == 1:
+                // Excel counts from 1 and errors when the text is absent, .NET counts from 0 and returns -1
+                return $"IFERROR(FIND({InternalConvert(args[0])},{target})-1,-1)";
+            default:
+                return null;
+        }
+    }
+
+    private string? ConvertMathCall(MethodCallExpression exp)
+    {
+        var args = exp.Arguments;
+        var name = exp.Method.Name;
+        // Math.Round is deliberately absent: it rounds halves to even where Excel's ROUND rounds them
+        // away from zero, so there is no formula that means the same thing. Overloads taking a
+        // MidpointRounding are rejected outright rather than falling through to a near equivalent.
+        if (args.Any(a => a.Type == typeof(MidpointRounding))) return null;
+        if (DirectMathMethods.Contains(name))
+            return $"{name.ToUpperInvariant()}({JoinArguments(args)})";
+        switch (name)
+        {
+            case nameof(System.Math.Pow):
+                return $"POWER({JoinArguments(args)})";
+            case nameof(System.Math.Atan2):
+                // .NET takes (y, x), Excel takes (x_num, y_num)
+                return $"ATAN2({InternalConvert(args[1])},{InternalConvert(args[0])})";
+            case nameof(System.Math.Log):
+                return args.Count == 1 ? $"LN({InternalConvert(args[0])})" : $"LOG({JoinArguments(args)})";
+            case nameof(System.Math.Ceiling):
+                return $"{Future("CEILING.MATH")}({InternalConvert(args[0])})";
+            case nameof(System.Math.Floor):
+                return $"{Future("FLOOR.MATH")}({InternalConvert(args[0])})";
+            case nameof(System.Math.Truncate):
+                return $"TRUNC({InternalConvert(args[0])})";
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>Converts a .NET 0-based offset to the 1-based position Excel's text functions take.</summary>
+    private string OneBased(Expression expression)
+    {
+        if (TryEvaluate(expression, out var value) && value is int index) return (index + 1).ToString();
+        var text = InternalConvert(expression);
+        return Precedence(expression) < 3 ? $"({text})+1" : $"{text}+1";
+    }
+
+    private string ConvertConditional(Expression expression)
+    {
+        if (expression is not ConditionalExpression exp) return "null";
+        return
+            $"IF({InternalConvert(exp.Test)},{InternalConvert(exp.IfTrue)},{InternalConvert(exp.IfFalse)})";
     }
 
     private string ConvertMemberAccess(Expression expression)
@@ -181,22 +422,48 @@ internal class ExpressionConvert
         if (ModelParameter != null && exp!.Expression == ModelParameter)
             return ConvertModelProperty(member);
         // m.Price.Value on a nullable property refers to the same cell
-        if (member.Name == "Value" && Nullable.GetUnderlyingType(member.DeclaringType!) != null)
-            return InternalConvert(exp!.Expression);
-        if (member.DeclaringType != typeof(DateTime))
-            return $"unspport member access type={member.DeclaringType} name={member.Name}";
+        var nullableUnderlyingType = member.DeclaringType == null
+            ? null
+            : Nullable.GetUnderlyingType(member.DeclaringType);
+        if (nullableUnderlyingType != null)
+        {
+            if (member.Name == "Value") return InternalConvert(exp!.Expression);
+            if (member.Name == "HasValue") return $"NOT(ISBLANK({InternalConvert(exp!.Expression)}))";
+        }
+
+        if (member.DeclaringType == typeof(DateTime) && ConvertDateTimeMember(exp!, member) is { } dateMember)
+            return dateMember;
+        if (member.DeclaringType == typeof(string) && member.Name == nameof(string.Length))
+            return $"LEN({InternalConvert(exp!.Expression)})";
+        // A member that uses nothing from the sheet is just a value, e.g. a variable the lambda captured.
+        if (TryEvaluate(exp!, out var value)) return FormatValue(value);
+        return $"unspport member access type={member.DeclaringType} name={member.Name}";
+    }
+
+    private string? ConvertDateTimeMember(MemberExpression exp, MemberInfo member)
+    {
         switch (member.Name)
         {
-            case "Now":
+            case nameof(DateTime.Now):
                 return "NOW()";
-            case "Year":
+            case nameof(DateTime.Today):
+                return "TODAY()";
+            case nameof(DateTime.Year):
                 return $"YEAR({InternalConvert(exp.Expression)})";
-            case "Month":
+            case nameof(DateTime.Month):
                 return $"MONTH({InternalConvert(exp.Expression)})";
-            case "Day":
+            case nameof(DateTime.Day):
                 return $"DAY({InternalConvert(exp.Expression)})";
+            case nameof(DateTime.Hour):
+                return $"HOUR({InternalConvert(exp.Expression)})";
+            case nameof(DateTime.Minute):
+                return $"MINUTE({InternalConvert(exp.Expression)})";
+            case nameof(DateTime.Second):
+                return $"SECOND({InternalConvert(exp.Expression)})";
+            case nameof(DateTime.Date):
+                return $"INT({InternalConvert(exp.Expression)})";
             default:
-                return $"unsupported member access type={member.DeclaringType} name={member.Name}";
+                return null;
         }
     }
 
@@ -213,7 +480,17 @@ internal class ExpressionConvert
 
     private string ConvertUnaryExpression(Expression expression)
     {
-        if (!(expression is UnaryExpression unary)) return "null";
+        if (expression is not UnaryExpression unary) return "null";
+        // ExpressionType.Not covers both !x and ~x; Excel has no bitwise complement
+        if (unary.NodeType == ExpressionType.Not)
+        {
+            var type = Nullable.GetUnderlyingType(unary.Type) ?? unary.Type;
+            if (type == typeof(bool) || type == typeof(ColumnValue))
+                return $"NOT({InternalConvert(unary.Operand)})";
+            return $"unsupported unary symbol:~ on {type.Name}";
+        }
+        if (unary.NodeType == ExpressionType.UnaryPlus)
+            return InternalConvert(unary.Operand);
         var symbol = unary.NodeType == ExpressionType.Negate ? "-" : "unsupported unary symbol";
         var operand = InternalConvert(unary.Operand);
         if (Precedence(unary.Operand) != int.MaxValue) operand = $"({operand})";
@@ -241,12 +518,18 @@ internal class ExpressionConvert
                     : $"{prefix}{GetColumn(args[0], sheetTitle)}{RowIndex + 1}";
             case nameof(SheetCellDictionary.Matrix):
                 return
-                    $"{prefix}{GetColumn(args[0], sheetTitle)}{args[1]}:{GetColumn(args[2], sheetTitle)}{args[3]}";
+                    $"{prefix}{GetColumn(args[0], sheetTitle)}{ConvertRowNumber(args[1])}:{GetColumn(args[2], sheetTitle)}{ConvertRowNumber(args[3])}";
             case nameof(SheetCellDictionary.Columns):
                 return $"{prefix}{GetColumn(args[0], sheetTitle)}:{GetColumn(args[1], sheetTitle)}";
             default:
                 return $"unspport call type={exp.Method.DeclaringType} name={exp.Method.Name}";
         }
+    }
+
+    /// <summary>Row numbers of a range are plain integers, whether written inline or held in a variable.</summary>
+    private string ConvertRowNumber(Expression expression)
+    {
+        return TryEvaluate(expression, out var value) ? FormatValue(value) : InternalConvert(expression);
     }
 
     /// <summary>
@@ -268,17 +551,75 @@ internal class ExpressionConvert
         {
             case ConstantExpression constant:
                 return constant.Value;
-            case MemberExpression { Expression: ConstantExpression closure, Member: System.Reflection.FieldInfo field }:
+            case MemberExpression {Expression: ConstantExpression closure, Member: FieldInfo field}:
                 return field.GetValue(closure.Value);
             default:
-                return null;
+                return TryEvaluate(exp, out var value) ? value : null;
         }
+    }
+
+    /// <summary>
+    ///     Evaluates a sub-expression that refers to nothing in the sheet - a captured variable, a
+    ///     constant folded call - so it can be written into the formula as a literal.
+    /// </summary>
+    /// <remarks>
+    ///     A converter is built per row, so this runs once per row per literal. The two shapes that
+    ///     cover almost everything - a literal, and the field access the compiler emits for a captured
+    ///     variable - are read directly; only the rest falls back to compiling, and that compilation is
+    ///     cached against the expression node, which the formula column reuses for every row.
+    /// </remarks>
+    private static bool TryEvaluate(Expression expression, out object? value)
+    {
+        switch (expression)
+        {
+            case ConstantExpression constant:
+                value = constant.Value;
+                return true;
+            case MemberExpression {Expression: ConstantExpression owner} member:
+                switch (member.Member)
+                {
+                    case FieldInfo field:
+                        value = field.GetValue(owner.Value);
+                        return true;
+                    case PropertyInfo property when property.GetIndexParameters().Length == 0:
+                        value = property.GetValue(owner.Value);
+                        return true;
+                }
+
+                break;
+        }
+
+        value = null;
+        if (ContainsParameter(expression)) return false;
+        try
+        {
+            value = Evaluators.GetValue(expression, Compile)();
+            return true;
+        }
+        catch
+        {
+            // Anything that only makes sense as formula text (the ColumnValue members all throw) is
+            // not a value, and is translated by the callers instead.
+            return false;
+        }
+    }
+
+    private static Func<object?> Compile(Expression expression)
+    {
+        return Expression.Lambda<Func<object?>>(Expression.Convert(expression, typeof(object))).Compile();
+    }
+
+    private static bool ContainsParameter(Expression expression)
+    {
+        var finder = new ParameterFinder();
+        finder.Visit(expression);
+        return finder.Found;
     }
 
     private string GetColumn(Expression exp)
     {
-        if (exp is not ConstantExpression constant) return "null";
-        return GetColumnByTitle(constant.Value?.ToString());
+        if (GetConstantValue(exp)?.ToString() is not { } title) return "null";
+        return GetColumnByTitle(title);
     }
 
     private string GetColumnByTitle(string? title)
@@ -324,6 +665,8 @@ internal class ExpressionConvert
                 return ConvertMemberAccess(expression);
             case ExpressionType.Constant:
                 return ConvertConstant(expression);
+            case ExpressionType.Conditional:
+                return ConvertConditional(expression);
         }
 
         switch (expression)
@@ -334,8 +677,23 @@ internal class ExpressionConvert
                 return ConvertUnaryExpression(expression);
         }
 
-        if (expression.NodeType != ExpressionType.NewArrayInit) return $"unsupported type {expressions[0]?.NodeType}";
-        if (expression is not NewArrayExpression exp) return "null";
-        return string.Join(",", exp.Expressions.Select(c => InternalConvert(c)));
+        // params arrays are spread into the argument list of the function that takes them
+        if (expression.NodeType == ExpressionType.NewArrayInit && expression is NewArrayExpression exp)
+            return string.Join(",", exp.Expressions.Select(c => InternalConvert(c)));
+        // anything else that does not touch the sheet, e.g. new DateTime(2024, 3, 1), is a literal
+        if (TryEvaluate(expression, out var value)) return FormatValue(value);
+        return $"unsupported type {expression.NodeType}";
+    }
+
+    /// <summary>Tells whether an expression depends on a lambda parameter, i.e. on the sheet.</summary>
+    private class ParameterFinder : ExpressionVisitor
+    {
+        public bool Found { get; private set; }
+
+        protected override Expression VisitParameter(ParameterExpression node)
+        {
+            Found = true;
+            return node;
+        }
     }
 }

--- a/ExcelFunctions.md
+++ b/ExcelFunctions.md
@@ -1,3 +1,9 @@
+# Excel Functions in Formula Columns
+
+A formula column is a C# lambda that is never executed: it is read as an expression tree and translated
+to Excel formula text. **334 Excel functions** are available, in ten categories, plus the C# operators and
+a set of ordinary .NET members that map onto Excel functions.
+
 ### Use formula
 
 ``` csharp
@@ -70,68 +76,479 @@ when the formula column is written, e.g. write it first and append the formula s
 Sheet titles are always quoted, so titles with spaces or apostrophes work. If a title cannot be found on the other
 sheet, a plain column letter (`"A"`, `"BC"`) is used as-is; any other unknown title throws `Excel2ObjectException`.
 
+### Ranges and single values
 
-### Math Functions
+Ranges are `ColumnMatrix` values - `c.Matrix("One", 2, "One", 9)`, `c.Columns("One", "Four")`,
+`c.Sheet("Products").Matrix(...)` - and a range converts to a single value implicitly, so functions that
+accept either take both:
 
-|Function|Syntax |Description|
-|:---|:---|:----|
-|ABS | ```  c => ExcelFunctions.Math.Abs(c["One"]) ```|
-|PI|```  c => ExcelFunctions.Math.PI() ```|
+``` csharp
+c => ExcelFunctions.Statistics.Sum(c["Qty"], c.Matrix("Qty", 2, "Qty", 9))   // =SUM(C4,C2:C9)
+c => ExcelFunctions.Math.SumIf(c.Matrix("Qty", 2, "Qty", 9), ">100",
+         c.Matrix("Price", 2, "Price", 9))                                   // =SUMIF(C2:C9,">100",B2:B9)
+```
 
-### Statistics Functions
+Functions that take criteria pairs (`SUMIFS`, `COUNTIFS`, `AVERAGEIFS`, `MAXIFS`, `MINIFS`, `IFS`, `SWITCH`)
+take them as trailing arguments, in the order Excel expects them.
 
-|Function|Syntax |Description|
-|:---|:---|:----|
-|SUM | ``` c => ExcelFunctions.Statistics.Sum(c.Matix("One", 1, "Two", 2), c.Matrix("Six", 11, "Five", 2)) ```|SUM(A1:B2,F11:E2)|
+### C# written straight into a formula
 
-### Condition Functions
-|Function|Syntax |Description|
-|:---|:---|:----|
-|IF | ``` c => ExcelFunctions.Statistics.Sum(c.Matix("One", 1, "Two", 2), c.Matrix("Six", 11, "Five", 2)) ```|SUM(A1:B2,F11:E2)|
+Besides the function library, ordinary C# inside the lambda is translated. This works on cells
+(`c["Qty"] > 5 && c["Price"] > 1`) as well as on model properties:
 
-### Reference Functions
-|Function|Syntax |Description|
-|:---|:---|:----|
-|LOOKUP | ``` c => ExcelFunctions.Reference.Lookup(4.19,c.Matrix("One", 2, "One", 6),c.Matrix("Two", 2, "Two", 6)) ```|LOOKUP(4.19, A2:A6, B2:B6)|
-|VLOOKUP | ```c => ExcelFunctions.Reference.VLookup(c["One"], c.Matrix("One", 10, "Three", 20), 2, true)```| VLOOKUP(A4,A10:C20,2,TRUE)|
-|MATCH|
-|CHOOSE|
-|INDEX|
+|C#|Formula|
+|:---|:---|
+|`a + b`, `a - b`, `a * b`, `a / b`|`a+b`, `a-b`, `a*b`, `a/b`|
+|`"x" + a` (string)|`"x"&a`|
+|`a % b`|`MOD(a,b)`|
+|`a ^ b` (on a cell)|`a^b` (Excel's power operator, not a bitwise xor)|
+|`a & b`, `a \| b`, `a ^ b` (on integers)|`_xlfn.BITAND(a,b)`, `_xlfn.BITOR(a,b)`, `_xlfn.BITXOR(a,b)`|
+|`-a`|`-a`|
+|`a == b`, `a != b`, `a > b`, `a >= b`, `a < b`, `a <= b`|`a=b`, `a<>b`, `a>b`, `a>=b`, `a<b`, `a<=b`|
+|`a && b`, `a \|\| b`, `!a`, `a ^ b` (on bools)|`AND(a,b)`, `OR(a,b)`, `NOT(a)`, `_xlfn.XOR(a,b)`|
+|`d.Ticks` below a second|added as its fraction of a day, since `TIME` takes whole seconds|
+|`cond ? x : y`|`IF(cond,x,y)`|
+|`Math.Abs/Sqrt/Pow/Ceiling/Floor/Truncate/Log/Max/Min/...`|`ABS`, `SQRT`, `POWER`, `_xlfn.CEILING.MATH`, `_xlfn.FLOOR.MATH`, ...|
+|`s.ToUpper()`, `s.ToLower()`, `s.Length`|`UPPER(s)`, `LOWER(s)`, `LEN(s)`|
+|`s.Substring(i)`, `s.Substring(i, n)`|`MID(s,i+1,LEN(s))`, `MID(s,i+1,n)`|
+|`s.Replace(a, b)`, `s.Contains(x)`|`SUBSTITUTE(s,a,b)`, `ISNUMBER(FIND(x,s))`|
+|`s.StartsWith(x)`, `s.EndsWith(x)`, `s.IndexOf(x)`|`EXACT(LEFT(s,LEN(x)),x)`, `EXACT(RIGHT(...),x)`, `IFERROR(FIND(x,s)-1,-1)`|
+|`DateTime.Now`, `DateTime.Today`|`NOW()`, `TODAY()`|
+|`d.Year/Month/Day/Hour/Minute/Second`|`YEAR(d)`, `MONTH(d)`, ...|
+|`d.AddMonths(n)`, `d.AddYears(n)`, `d.AddDays(n)`|`EDATE(d,n)`, `EDATE(d,(n)*12)`, `(d+n)`|
+|`p.Value`, `p.HasValue` (nullable)|the cell itself, `NOT(ISBLANK(cell))`|
+|a captured variable, `new DateTime(2024, 3, 1)`|the value as a literal, `DATE(2024,3,1)`|
 
-### Date and Time Functions
-|Function|Syntax |Description  |
-|:---|:---|:-----|
-|DATE |                        |
-|DATEDIF |                     |
-|DAYS||
+`FIND` and `EXACT` are used rather than `SEARCH` and `=` because the .NET methods are case sensitive and
+take no wildcards, and `IndexOf` is wrapped in `IFERROR` because Excel errors where .NET returns -1.
 
-### Text Functions
-|Function|Syntax |Description|
-|---|:---|:------|
-|FIND | ```c => ExcelFunctions.Text.Find("M",c["One",2]) ```|FIND("M",A2)     |
-|ASC |                                                                         |
+Only members Excel can express exactly are translated; a member whose Excel counterpart would compute
+something else is left unsupported rather than translated to a near equivalent:
+
+- `Math.Round` rounds halves to even, Excel's `ROUND` rounds them away from zero
+- `string.Trim()` strips only the ends, Excel's `TRIM` also collapses runs of spaces inside the text
+- `string.IsNullOrWhiteSpace` counts tabs and the Unicode spaces that Excel's `TRIM` does not
+- `IndexOf(text, startIndex)` and any overload taking a `StringComparison`, a `CultureInfo` or a
+  `MidpointRounding` would have to drop an argument Excel has nowhere to put
+
+Call `ExcelFunctions.Math.Round(...)` or `ExcelFunctions.Text.Trim(...)` when the Excel function is what
+you want - then the formula says so explicitly.
+
+Numbers are always written with an invariant decimal point, and text literals are quoted with embedded
+quotes doubled, so a formula built under any culture parses in Excel.
+
+## Function reference
+
+¹ Marks a function Excel gained after the 2007 file format was fixed. Those are *stored* under an
+`_xlfn.` prefix (`_xlfn.IFS`, `_xlfn.STDEV.P`, and `_xlfn._xlws.FILTER` / `_xlfn._xlws.SORT` for the two
+worksheet-only ones) - Excel shows them without it. This library adds the prefix for you; a workbook that
+stores the bare name shows `#NAME?` instead of a result. Your Excel version still has to have the function.
+
+### Math and Trigonometry Functions (73)
+
+|Function|C#|
+|:---|:---|
+|ABS|`ExcelFunctions.Math.Abs(...)`|
+|ACOS|`ExcelFunctions.Math.Acos(...)`|
+|ACOSH|`ExcelFunctions.Math.Acosh(...)`|
+|ACOT ¹|`ExcelFunctions.Math.Acot(...)`|
+|ACOTH ¹|`ExcelFunctions.Math.Acoth(...)`|
+|AGGREGATE ¹|`ExcelFunctions.Math.Aggregate(...)`|
+|ARABIC ¹|`ExcelFunctions.Math.Arabic(...)`|
+|ASIN|`ExcelFunctions.Math.Asin(...)`|
+|ASINH|`ExcelFunctions.Math.Asinh(...)`|
+|ATAN|`ExcelFunctions.Math.Atan(...)`|
+|ATAN2|`ExcelFunctions.Math.Atan2(...)`|
+|ATANH|`ExcelFunctions.Math.Atanh(...)`|
+|BASE ¹|`ExcelFunctions.Math.Base(...)`|
+|CEILING|`ExcelFunctions.Math.Ceiling(...)`|
+|CEILING.MATH ¹|`ExcelFunctions.Math.CeilingMath(...)`|
+|COMBIN|`ExcelFunctions.Math.Combin(...)`|
+|COMBINA ¹|`ExcelFunctions.Math.CombinA(...)`|
+|COS|`ExcelFunctions.Math.Cos(...)`|
+|COSH|`ExcelFunctions.Math.Cosh(...)`|
+|COT ¹|`ExcelFunctions.Math.Cot(...)`|
+|COTH ¹|`ExcelFunctions.Math.Coth(...)`|
+|CSC ¹|`ExcelFunctions.Math.Csc(...)`|
+|CSCH ¹|`ExcelFunctions.Math.Csch(...)`|
+|DECIMAL ¹|`ExcelFunctions.Math.Decimal(...)`|
+|DEGREES|`ExcelFunctions.Math.Degrees(...)`|
+|EVEN|`ExcelFunctions.Math.Even(...)`|
+|EXP|`ExcelFunctions.Math.Exp(...)`|
+|FACT|`ExcelFunctions.Math.Fact(...)`|
+|FACTDOUBLE|`ExcelFunctions.Math.FactDouble(...)`|
+|FLOOR|`ExcelFunctions.Math.Floor(...)`|
+|FLOOR.MATH ¹|`ExcelFunctions.Math.FloorMath(...)`|
+|GCD|`ExcelFunctions.Math.Gcd(...)`|
+|INT|`ExcelFunctions.Math.Int(...)`|
+|LCM|`ExcelFunctions.Math.Lcm(...)`|
+|LN|`ExcelFunctions.Math.Ln(...)`|
+|LOG|`ExcelFunctions.Math.Log(...)`|
+|LOG10|`ExcelFunctions.Math.Log10(...)`|
+|MDETERM|`ExcelFunctions.Math.MDeterm(...)`|
+|MINVERSE|`ExcelFunctions.Math.MInverse(...)`|
+|MMULT|`ExcelFunctions.Math.MMult(...)`|
+|MOD|`ExcelFunctions.Math.Mod(...)`|
+|MROUND|`ExcelFunctions.Math.MRound(...)`|
+|MULTINOMIAL|`ExcelFunctions.Math.MultiNomial(...)`|
+|MUNIT ¹|`ExcelFunctions.Math.MUnit(...)`|
+|ODD|`ExcelFunctions.Math.Odd(...)`|
+|PI|`ExcelFunctions.Math.PI(...)`|
+|POWER|`ExcelFunctions.Math.Power(...)`|
+|PRODUCT|`ExcelFunctions.Math.Product(...)`|
+|QUOTIENT|`ExcelFunctions.Math.Quotient(...)`|
+|RADIANS|`ExcelFunctions.Math.Radians(...)`|
+|RAND|`ExcelFunctions.Math.Rand(...)`|
+|RANDARRAY ¹|`ExcelFunctions.Math.RandArray(...)`|
+|RANDBETWEEN|`ExcelFunctions.Math.RandBetween(...)`|
+|ROMAN|`ExcelFunctions.Math.Roman(...)`|
+|ROUND|`ExcelFunctions.Math.Round(...)`|
+|ROUNDDOWN|`ExcelFunctions.Math.RoundDown(...)`|
+|ROUNDUP|`ExcelFunctions.Math.RoundUp(...)`|
+|SEC ¹|`ExcelFunctions.Math.Sec(...)`|
+|SECH ¹|`ExcelFunctions.Math.Sech(...)`|
+|SERIESSUM|`ExcelFunctions.Math.SeriesSum(...)`|
+|SIGN|`ExcelFunctions.Math.Sign(...)`|
+|SIN|`ExcelFunctions.Math.Sin(...)`|
+|SINH|`ExcelFunctions.Math.Sinh(...)`|
+|SQRT|`ExcelFunctions.Math.Sqrt(...)`|
+|SQRTPI|`ExcelFunctions.Math.SqrtPi(...)`|
+|SUBTOTAL|`ExcelFunctions.Math.Subtotal(...)`|
+|SUMIF|`ExcelFunctions.Math.SumIf(...)`|
+|SUMIFS|`ExcelFunctions.Math.SumIfs(...)`|
+|SUMPRODUCT|`ExcelFunctions.Math.SumProduct(...)`|
+|SUMSQ|`ExcelFunctions.Math.SumSq(...)`|
+|TAN|`ExcelFunctions.Math.Tan(...)`|
+|TANH|`ExcelFunctions.Math.Tanh(...)`|
+|TRUNC|`ExcelFunctions.Math.Trunc(...)`|
+
+### Statistical Functions (80)
+
+|Function|C#|
+|:---|:---|
+|AVEDEV|`ExcelFunctions.Statistics.AveDev(...)`|
+|AVERAGE|`ExcelFunctions.Statistics.Average(...)`|
+|AVERAGEA|`ExcelFunctions.Statistics.AverageA(...)`|
+|AVERAGEIF|`ExcelFunctions.Statistics.AverageIf(...)`|
+|AVERAGEIFS|`ExcelFunctions.Statistics.AverageIfs(...)`|
+|BINOM.DIST ¹|`ExcelFunctions.Statistics.BinomDist(...)`|
+|CHISQ.TEST ¹|`ExcelFunctions.Statistics.ChiSqTest(...)`|
+|CONFIDENCE.NORM ¹|`ExcelFunctions.Statistics.ConfidenceNorm(...)`|
+|CONFIDENCE.T ¹|`ExcelFunctions.Statistics.ConfidenceT(...)`|
+|CORREL|`ExcelFunctions.Statistics.Correl(...)`|
+|COUNT|`ExcelFunctions.Statistics.Count(...)`|
+|COUNTA|`ExcelFunctions.Statistics.CountA(...)`|
+|COUNTBLANK|`ExcelFunctions.Statistics.CountBlank(...)`|
+|COUNTIF|`ExcelFunctions.Statistics.CountIf(...)`|
+|COUNTIFS|`ExcelFunctions.Statistics.CountIfs(...)`|
+|COVARIANCE.P ¹|`ExcelFunctions.Statistics.CovarianceP(...)`|
+|COVARIANCE.S ¹|`ExcelFunctions.Statistics.CovarianceS(...)`|
+|DEVSQ|`ExcelFunctions.Statistics.DevSq(...)`|
+|EXPON.DIST ¹|`ExcelFunctions.Statistics.ExponDist(...)`|
+|FORECAST|`ExcelFunctions.Statistics.Forecast(...)`|
+|FORECAST.LINEAR ¹|`ExcelFunctions.Statistics.ForecastLinear(...)`|
+|FREQUENCY|`ExcelFunctions.Statistics.Frequency(...)`|
+|GEOMEAN|`ExcelFunctions.Statistics.GeoMean(...)`|
+|GROWTH|`ExcelFunctions.Statistics.Growth(...)`|
+|HARMEAN|`ExcelFunctions.Statistics.HarMean(...)`|
+|INTERCEPT|`ExcelFunctions.Statistics.Intercept(...)`|
+|KURT|`ExcelFunctions.Statistics.Kurt(...)`|
+|LARGE|`ExcelFunctions.Statistics.Large(...)`|
+|LINEST|`ExcelFunctions.Statistics.LinEst(...)`|
+|LOGEST|`ExcelFunctions.Statistics.LogEst(...)`|
+|MAX|`ExcelFunctions.Statistics.Max(...)`|
+|MAXA|`ExcelFunctions.Statistics.MaxA(...)`|
+|MAXIFS ¹|`ExcelFunctions.Statistics.MaxIfs(...)`|
+|MEDIAN|`ExcelFunctions.Statistics.Median(...)`|
+|MIN|`ExcelFunctions.Statistics.Min(...)`|
+|MINA|`ExcelFunctions.Statistics.MinA(...)`|
+|MINIFS ¹|`ExcelFunctions.Statistics.MinIfs(...)`|
+|MODE|`ExcelFunctions.Statistics.Mode(...)`|
+|MODE.MULT ¹|`ExcelFunctions.Statistics.ModeMult(...)`|
+|MODE.SNGL ¹|`ExcelFunctions.Statistics.ModeSngl(...)`|
+|NORM.DIST ¹|`ExcelFunctions.Statistics.NormDist(...)`|
+|NORM.INV ¹|`ExcelFunctions.Statistics.NormInv(...)`|
+|NORM.S.DIST ¹|`ExcelFunctions.Statistics.NormSDist(...)`|
+|NORM.S.INV ¹|`ExcelFunctions.Statistics.NormSInv(...)`|
+|PERCENTILE|`ExcelFunctions.Statistics.Percentile(...)`|
+|PERCENTILE.EXC ¹|`ExcelFunctions.Statistics.PercentileExc(...)`|
+|PERCENTILE.INC ¹|`ExcelFunctions.Statistics.PercentileInc(...)`|
+|PERCENTRANK|`ExcelFunctions.Statistics.PercentRank(...)`|
+|PERMUT|`ExcelFunctions.Statistics.Permut(...)`|
+|PERMUTATIONA ¹|`ExcelFunctions.Statistics.PermutationA(...)`|
+|POISSON.DIST ¹|`ExcelFunctions.Statistics.PoissonDist(...)`|
+|PROB|`ExcelFunctions.Statistics.Prob(...)`|
+|QUARTILE|`ExcelFunctions.Statistics.Quartile(...)`|
+|QUARTILE.EXC ¹|`ExcelFunctions.Statistics.QuartileExc(...)`|
+|QUARTILE.INC ¹|`ExcelFunctions.Statistics.QuartileInc(...)`|
+|RANK|`ExcelFunctions.Statistics.Rank(...)`|
+|RANK.AVG ¹|`ExcelFunctions.Statistics.RankAvg(...)`|
+|RANK.EQ ¹|`ExcelFunctions.Statistics.RankEq(...)`|
+|RSQ|`ExcelFunctions.Statistics.Rsq(...)`|
+|SKEW|`ExcelFunctions.Statistics.Skew(...)`|
+|SLOPE|`ExcelFunctions.Statistics.Slope(...)`|
+|SMALL|`ExcelFunctions.Statistics.Small(...)`|
+|STANDARDIZE|`ExcelFunctions.Statistics.Standardize(...)`|
+|STDEV|`ExcelFunctions.Statistics.StDev(...)`|
+|STDEV.P ¹|`ExcelFunctions.Statistics.StDevP(...)`|
+|STDEV.S ¹|`ExcelFunctions.Statistics.StDevS(...)`|
+|STDEVA|`ExcelFunctions.Statistics.StDevA(...)`|
+|STDEVPA|`ExcelFunctions.Statistics.StDevPA(...)`|
+|STEYX|`ExcelFunctions.Statistics.SteyX(...)`|
+|SUM|`ExcelFunctions.Statistics.Sum(...)`|
+|T.DIST ¹|`ExcelFunctions.Statistics.TDist(...)`|
+|T.INV ¹|`ExcelFunctions.Statistics.TInv(...)`|
+|T.TEST ¹|`ExcelFunctions.Statistics.TTest(...)`|
+|TREND|`ExcelFunctions.Statistics.Trend(...)`|
+|TRIMMEAN|`ExcelFunctions.Statistics.TrimMean(...)`|
+|VAR|`ExcelFunctions.Statistics.Var(...)`|
+|VAR.P ¹|`ExcelFunctions.Statistics.VarP(...)`|
+|VAR.S ¹|`ExcelFunctions.Statistics.VarS(...)`|
+|VARA|`ExcelFunctions.Statistics.VarA(...)`|
+|VARPA|`ExcelFunctions.Statistics.VarPA(...)`|
+
+### Logical Functions (11)
+
+|Function|C#|
+|:---|:---|
+|AND|`ExcelFunctions.Condition.And(...)`|
+|FALSE|`ExcelFunctions.Condition.False(...)`|
+|IF|`ExcelFunctions.Condition.If(...)`|
+|IFERROR|`ExcelFunctions.Condition.IfError(...)`|
+|IFNA ¹|`ExcelFunctions.Condition.IfNa(...)`|
+|IFS ¹|`ExcelFunctions.Condition.Ifs(...)`|
+|NOT|`ExcelFunctions.Condition.Not(...)`|
+|OR|`ExcelFunctions.Condition.Or(...)`|
+|SWITCH ¹|`ExcelFunctions.Condition.Switch(...)`|
+|TRUE|`ExcelFunctions.Condition.True(...)`|
+|XOR ¹|`ExcelFunctions.Condition.Xor(...)`|
+
+### Lookup and Reference Functions (33)
+
+|Function|C#|
+|:---|:---|
+|ADDRESS|`ExcelFunctions.Reference.Address(...)`|
+|AREAS|`ExcelFunctions.Reference.Areas(...)`|
+|CHOOSE|`ExcelFunctions.Reference.Choose(...)`|
+|CHOOSECOLS ¹|`ExcelFunctions.Reference.ChooseCols(...)`|
+|CHOOSEROWS ¹|`ExcelFunctions.Reference.ChooseRows(...)`|
+|COLUMN|`ExcelFunctions.Reference.Column(...)`|
+|COLUMNS|`ExcelFunctions.Reference.Columns(...)`|
+|DROP ¹|`ExcelFunctions.Reference.Drop(...)`|
+|EXPAND ¹|`ExcelFunctions.Reference.Expand(...)`|
+|FILTER ¹|`ExcelFunctions.Reference.Filter(...)`|
+|FORMULATEXT ¹|`ExcelFunctions.Reference.FormulaText(...)`|
+|HLOOKUP|`ExcelFunctions.Reference.HLookup(...)`|
+|HSTACK ¹|`ExcelFunctions.Reference.HStack(...)`|
+|HYPERLINK|`ExcelFunctions.Reference.Hyperlink(...)`|
+|INDEX|`ExcelFunctions.Reference.Index(...)`|
+|INDIRECT|`ExcelFunctions.Reference.Indirect(...)`|
+|LOOKUP|`ExcelFunctions.Reference.Lookup(...)`|
+|MATCH|`ExcelFunctions.Reference.Match(...)`|
+|OFFSET|`ExcelFunctions.Reference.Offset(...)`|
+|ROW|`ExcelFunctions.Reference.Row(...)`|
+|ROWS|`ExcelFunctions.Reference.Rows(...)`|
+|SEQUENCE ¹|`ExcelFunctions.Reference.Sequence(...)`|
+|SORT ¹|`ExcelFunctions.Reference.Sort(...)`|
+|SORTBY ¹|`ExcelFunctions.Reference.SortBy(...)`|
+|TAKE ¹|`ExcelFunctions.Reference.Take(...)`|
+|TOCOL ¹|`ExcelFunctions.Reference.ToCol(...)`|
+|TOROW ¹|`ExcelFunctions.Reference.ToRow(...)`|
+|TRANSPOSE|`ExcelFunctions.Reference.Transpose(...)`|
+|UNIQUE ¹|`ExcelFunctions.Reference.Unique(...)`|
+|VLOOKUP|`ExcelFunctions.Reference.VLookup(...)`|
+|VSTACK ¹|`ExcelFunctions.Reference.VStack(...)`|
+|XLOOKUP ¹|`ExcelFunctions.Reference.XLookup(...)`|
+|XMATCH ¹|`ExcelFunctions.Reference.XMatch(...)`|
+
+### Date and Time Functions (25)
+
+|Function|C#|
+|:---|:---|
+|DATE|`ExcelFunctions.DateAndTime.Date(...)`|
+|DATEDIF|`ExcelFunctions.DateAndTime.DateDif(...)`|
+|DATEVALUE|`ExcelFunctions.DateAndTime.DateValue(...)`|
+|DAY|`ExcelFunctions.DateAndTime.Day(...)`|
+|DAYS ¹|`ExcelFunctions.DateAndTime.Days(...)`|
+|DAYS360|`ExcelFunctions.DateAndTime.Days360(...)`|
+|EDATE|`ExcelFunctions.DateAndTime.EDate(...)`|
+|EOMONTH|`ExcelFunctions.DateAndTime.EoMonth(...)`|
+|HOUR|`ExcelFunctions.DateAndTime.Hour(...)`|
+|ISOWEEKNUM ¹|`ExcelFunctions.DateAndTime.IsoWeekNum(...)`|
+|MINUTE|`ExcelFunctions.DateAndTime.Minute(...)`|
+|MONTH|`ExcelFunctions.DateAndTime.Month(...)`|
+|NETWORKDAYS|`ExcelFunctions.DateAndTime.NetworkDays(...)`|
+|NETWORKDAYS.INTL ¹|`ExcelFunctions.DateAndTime.NetworkDaysIntl(...)`|
+|NOW|`ExcelFunctions.DateAndTime.Now(...)`|
+|SECOND|`ExcelFunctions.DateAndTime.Second(...)`|
+|TIME|`ExcelFunctions.DateAndTime.Time(...)`|
+|TIMEVALUE|`ExcelFunctions.DateAndTime.TimeValue(...)`|
+|TODAY|`ExcelFunctions.DateAndTime.Today(...)`|
+|WEEKDAY|`ExcelFunctions.DateAndTime.Weekday(...)`|
+|WEEKNUM|`ExcelFunctions.DateAndTime.WeekNum(...)`|
+|WORKDAY|`ExcelFunctions.DateAndTime.WorkDay(...)`|
+|WORKDAY.INTL ¹|`ExcelFunctions.DateAndTime.WorkDayIntl(...)`|
+|YEAR|`ExcelFunctions.DateAndTime.Year(...)`|
+|YEARFRAC|`ExcelFunctions.DateAndTime.YearFrac(...)`|
+
+### Text Functions (39)
+
+|Function|C#|
+|:---|:---|
+|ASC|`ExcelFunctions.Text.Asc(...)`|
+|CHAR|`ExcelFunctions.Text.Char(...)`|
+|CLEAN|`ExcelFunctions.Text.Clean(...)`|
+|CODE|`ExcelFunctions.Text.Code(...)`|
+|CONCAT ¹|`ExcelFunctions.Text.Concat(...)`|
+|CONCATENATE|`ExcelFunctions.Text.Concatenate(...)`|
+|DOLLAR|`ExcelFunctions.Text.Dollar(...)`|
+|EXACT|`ExcelFunctions.Text.Exact(...)`|
+|FIND|`ExcelFunctions.Text.Find(...)`|
+|FINDB|`ExcelFunctions.Text.FindB(...)`|
+|FIXED|`ExcelFunctions.Text.Fixed(...)`|
+|LEFT|`ExcelFunctions.Text.Left(...)`|
+|LEFTB|`ExcelFunctions.Text.LeftB(...)`|
+|LEN|`ExcelFunctions.Text.Len(...)`|
+|LENB|`ExcelFunctions.Text.LenB(...)`|
+|LOWER|`ExcelFunctions.Text.Lower(...)`|
+|MID|`ExcelFunctions.Text.Mid(...)`|
+|MIDB|`ExcelFunctions.Text.MidB(...)`|
+|NUMBERVALUE ¹|`ExcelFunctions.Text.NumberValue(...)`|
+|PROPER|`ExcelFunctions.Text.Proper(...)`|
+|REPLACE|`ExcelFunctions.Text.Replace(...)`|
+|REPT|`ExcelFunctions.Text.Rept(...)`|
+|RIGHT|`ExcelFunctions.Text.Right(...)`|
+|RIGHTB|`ExcelFunctions.Text.RightB(...)`|
+|SEARCH|`ExcelFunctions.Text.Search(...)`|
+|SEARCHB|`ExcelFunctions.Text.SearchB(...)`|
+|SUBSTITUTE|`ExcelFunctions.Text.Substitute(...)`|
+|T|`ExcelFunctions.Text.T(...)`|
+|TEXT|`ExcelFunctions.Text.Text(...)`|
+|TEXTAFTER ¹|`ExcelFunctions.Text.TextAfter(...)`|
+|TEXTBEFORE ¹|`ExcelFunctions.Text.TextBefore(...)`|
+|TEXTJOIN ¹|`ExcelFunctions.Text.TextJoin(...)`|
+|TEXTSPLIT ¹|`ExcelFunctions.Text.TextSplit(...)`|
+|TRIM|`ExcelFunctions.Text.Trim(...)`|
+|UNICHAR ¹|`ExcelFunctions.Text.UniChar(...)`|
+|UNICODE ¹|`ExcelFunctions.Text.Unicode(...)`|
+|UPPER|`ExcelFunctions.Text.Upper(...)`|
+|VALUE|`ExcelFunctions.Text.Value(...)`|
+|WIDECHAR|`ExcelFunctions.Text.WideChar(...)`|
+
+### Information Functions (20)
+
+|Function|C#|
+|:---|:---|
+|CELL|`ExcelFunctions.Information.Cell(...)`|
+|ERROR.TYPE|`ExcelFunctions.Information.ErrorType(...)`|
+|INFO|`ExcelFunctions.Information.Info(...)`|
+|ISBLANK|`ExcelFunctions.Information.IsBlank(...)`|
+|ISERR|`ExcelFunctions.Information.IsErr(...)`|
+|ISERROR|`ExcelFunctions.Information.IsError(...)`|
+|ISEVEN|`ExcelFunctions.Information.IsEven(...)`|
+|ISFORMULA ¹|`ExcelFunctions.Information.IsFormula(...)`|
+|ISLOGICAL|`ExcelFunctions.Information.IsLogical(...)`|
+|ISNA|`ExcelFunctions.Information.IsNa(...)`|
+|ISNONTEXT|`ExcelFunctions.Information.IsNonText(...)`|
+|ISNUMBER|`ExcelFunctions.Information.IsNumber(...)`|
+|ISODD|`ExcelFunctions.Information.IsOdd(...)`|
+|ISREF|`ExcelFunctions.Information.IsRef(...)`|
+|ISTEXT|`ExcelFunctions.Information.IsText(...)`|
+|N|`ExcelFunctions.Information.N(...)`|
+|NA|`ExcelFunctions.Information.Na(...)`|
+|SHEET ¹|`ExcelFunctions.Information.Sheet(...)`|
+|SHEETS ¹|`ExcelFunctions.Information.Sheets(...)`|
+|TYPE|`ExcelFunctions.Information.Type(...)`|
+
+### Financial Functions (21)
+
+|Function|C#|
+|:---|:---|
+|CUMIPMT|`ExcelFunctions.Financial.CumIPmt(...)`|
+|CUMPRINC|`ExcelFunctions.Financial.CumPrinc(...)`|
+|DB|`ExcelFunctions.Financial.Db(...)`|
+|DDB|`ExcelFunctions.Financial.Ddb(...)`|
+|EFFECT|`ExcelFunctions.Financial.Effect(...)`|
+|FV|`ExcelFunctions.Financial.Fv(...)`|
+|IPMT|`ExcelFunctions.Financial.IPmt(...)`|
+|IRR|`ExcelFunctions.Financial.Irr(...)`|
+|MIRR|`ExcelFunctions.Financial.MIrr(...)`|
+|NOMINAL|`ExcelFunctions.Financial.Nominal(...)`|
+|NPER|`ExcelFunctions.Financial.NPer(...)`|
+|NPV|`ExcelFunctions.Financial.Npv(...)`|
+|PMT|`ExcelFunctions.Financial.Pmt(...)`|
+|PPMT|`ExcelFunctions.Financial.PPmt(...)`|
+|PV|`ExcelFunctions.Financial.Pv(...)`|
+|RATE|`ExcelFunctions.Financial.Rate(...)`|
+|SLN|`ExcelFunctions.Financial.Sln(...)`|
+|SYD|`ExcelFunctions.Financial.Syd(...)`|
+|VDB|`ExcelFunctions.Financial.Vdb(...)`|
+|XIRR|`ExcelFunctions.Financial.XIrr(...)`|
+|XNPV|`ExcelFunctions.Financial.XNpv(...)`|
+
+### Engineering Functions (20)
+
+|Function|C#|
+|:---|:---|
+|BIN2DEC|`ExcelFunctions.Engineering.Bin2Dec(...)`|
+|BIN2HEX|`ExcelFunctions.Engineering.Bin2Hex(...)`|
+|BIN2OCT|`ExcelFunctions.Engineering.Bin2Oct(...)`|
+|BITAND ¹|`ExcelFunctions.Engineering.BitAnd(...)`|
+|BITLSHIFT ¹|`ExcelFunctions.Engineering.BitLShift(...)`|
+|BITOR ¹|`ExcelFunctions.Engineering.BitOr(...)`|
+|BITRSHIFT ¹|`ExcelFunctions.Engineering.BitRShift(...)`|
+|BITXOR ¹|`ExcelFunctions.Engineering.BitXor(...)`|
+|CONVERT|`ExcelFunctions.Engineering.Convert(...)`|
+|DEC2BIN|`ExcelFunctions.Engineering.Dec2Bin(...)`|
+|DEC2HEX|`ExcelFunctions.Engineering.Dec2Hex(...)`|
+|DEC2OCT|`ExcelFunctions.Engineering.Dec2Oct(...)`|
+|DELTA|`ExcelFunctions.Engineering.Delta(...)`|
+|GESTEP|`ExcelFunctions.Engineering.GeStep(...)`|
+|HEX2BIN|`ExcelFunctions.Engineering.Hex2Bin(...)`|
+|HEX2DEC|`ExcelFunctions.Engineering.Hex2Dec(...)`|
+|HEX2OCT|`ExcelFunctions.Engineering.Hex2Oct(...)`|
+|OCT2BIN|`ExcelFunctions.Engineering.Oct2Bin(...)`|
+|OCT2DEC|`ExcelFunctions.Engineering.Oct2Dec(...)`|
+|OCT2HEX|`ExcelFunctions.Engineering.Oct2Hex(...)`|
+
+### Database Functions (12)
+
+|Function|C#|
+|:---|:---|
+|DAVERAGE|`ExcelFunctions.Database.DAverage(...)`|
+|DCOUNT|`ExcelFunctions.Database.DCount(...)`|
+|DCOUNTA|`ExcelFunctions.Database.DCountA(...)`|
+|DGET|`ExcelFunctions.Database.DGet(...)`|
+|DMAX|`ExcelFunctions.Database.DMax(...)`|
+|DMIN|`ExcelFunctions.Database.DMin(...)`|
+|DPRODUCT|`ExcelFunctions.Database.DProduct(...)`|
+|DSTDEV|`ExcelFunctions.Database.DStDev(...)`|
+|DSTDEVP|`ExcelFunctions.Database.DStDevP(...)`|
+|DSUM|`ExcelFunctions.Database.DSum(...)`|
+|DVAR|`ExcelFunctions.Database.DVar(...)`|
+|DVARP|`ExcelFunctions.Database.DVarP(...)`|
 
 ### Symbol
 
-|Symbol|Mode|Synatx|Supported|Description|
+|Symbol|Mode|Syntax|Supported|Description|
 |---|---|---|:----|:----|
-|-|Unary|```c=>-c["One"]```|Yes                              |
-|+|Binary|```c=>c["One"]+c["Two"]```| Yes                   |
-|-|Binary|| Yes                                              |
-|\*|Binary|| Yes                                             |
-|/|Binary|| Yes                                              |
-|%|Binary                                                    |
-|\^|Binary                                                   |
-|=|Binary|```c=>c["One"]==c["Two"]```| Yes                  |
-|\<\> | Binary|```c=>c["One"]!=c["Two"]```| Yes             |
-|\>|Binary|| Yes                                             |
-|\<|Binary|| Yes                                             |
-|\>=|Binary|| Yes                                            |
-|\<=|Binary|| Yes                                            |
-|&|Binary|```c=>c["One"]&c["Two"]```|Yes|Join the string    |
-|:|Binary|```c => c.Matrix("One", 1, "Two", 2)```|Yes|A1:B2 |
-|,|Binary|||use params Array                                 |
-|Space|Binary                                                |
+|-|Unary|```c=>-c["One"]```|Yes||
+|+|Binary|```c=>c["One"]+c["Two"]```|Yes||
+|-|Binary||Yes||
+|\*|Binary||Yes||
+|/|Binary||Yes||
+|%|Binary|```c=>c["One"]%2```|Yes|Written as `MOD(A4,2)`|
+|\^|Binary|```c=>c["One"]^2```|Yes|Power|
+|=|Binary|```c=>c["One"]==c["Two"]```|Yes||
+|\<\> | Binary|```c=>c["One"]!=c["Two"]```|Yes||
+|\>|Binary||Yes||
+|\<|Binary||Yes||
+|\>=|Binary||Yes||
+|\<=|Binary||Yes||
+|&|Binary|```c=>c["One"]&c["Two"]```|Yes|Join the string|
+|:|Binary|```c => c.Matrix("One", 1, "Two", 2)```|Yes|A1:B2|
+|,|Binary||Yes|use params Array|
+|Space|Binary||No|Range intersection|
 
 #### Reference
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,21 @@ excel2obj generate-model orders.xlsx --class Order           # 由表头生成�
 - [x] 支持自动列宽 ✅ **v2.0.4 新增**
 - [x] 支持 Excel 日期/日期时间/时间格式 ✅ **v2.0.4 新增** - 查看 [DateTimeFormats.md](DateTimeFormats.md)
 - [x] 公式列引用同一工作簿的其他 sheet ✅ **v2.1.0 新增** - 查看 [ExcelFunctions.md](ExcelFunctions.md)
+- [x] 公式内置函数库 ✅ **v2.3.0 新增** - 334 个 Excel 函数，10 个类别 - 查看 [ExcelFunctions.md](ExcelFunctions.md)
 
 ### 发布说明
+
+* **2026.09.11** - v2.3.0
+- [x] ✨ **新增:** 公式内置函数库从 34 个扩充到 **334 个** Excel 函数，分 10 类：数学与三角（73）、统计（80）、逻辑（11）、查找与引用（33）、日期时间（25）、文本（39）、信息（20）、财务（21）、工程（20）、数据库（12）。信息 / 财务 / 工程 / 数据库为全新分类，入口为 `ExcelFunctions.Information`、`.Financial`、`.Engineering`、`.Database` - 查看 [ExcelFunctions.md](ExcelFunctions.md)
+- [x] 🐛 修复 Excel 2007 之后新增的函数写入后打开显示 `#NAME?` 的问题：xlsx 格式要求这类函数存成 `_xlfn.IFS`、`_xlfn.STDEV.P`（`SORT`/`FILTER` 为 `_xlfn._xlws.`），现已自动加前缀；此前已有的 `DAYS` 即受此影响
+- [x] 🐛 修复公式中的数字按当前区域性格式化的问题：`de-DE` 等区域下 `1.5` 会写成 `1,5` 导致公式无法解析，现统一使用不变区域性
+- [x] 🐛 修复文本字面量中的双引号未按 Excel 规则转义（`"` 需写成 `""`）的问题
+- [x] ✨ **新增:** 公式中可直接书写更多普通 C#：`%`（MOD）、`^`（乘幂）、`&&` / `||` / `!`（AND / OR / NOT）、三元表达式（IF）、`Math.*`、`string` 成员（`ToUpper`、`Substring`、`Length`、`Contains` 等；语义与 Excel 不完全一致的 `Math.Round`、`string.Trim` 等不翻译，需显式调用对应的 `ExcelFunctions` 函数）、`DateTime` 成员与 `AddDays` / `AddMonths` / `AddYears`、可空属性的 `.HasValue`
+- [x] ✨ **新增:** 公式中可引用 lambda 捕获的局部变量与 `new DateTime(...)` 等常量表达式，自动求值后写成字面量（此前会生成无效公式）
+- [x] ✨ **改进:** 区间（`c.Matrix(...)`、`c.Columns(...)`）可隐式用于接受单值的参数位置，`SUM` 等函数可混合传入单元格与区间
+- [x] 🐛 修复 `[ExcelColumn]` 的单元格样式被静默忽略的问题：样式缓存键与分支判断不匹配，`CellBold` / `CellFontColor` / `CellAlignment` 等此前完全没有写进单元格；另修复一列声明 `CellAlignment` 会改到工作簿默认样式、导致其他列跟着变的外溢问题（#47）
+- [x] 🐛 修复 `FormulaResultType = typeof(DateTime)` 的公式列没有日期格式、在 Excel 里显示成 `46282.6` 这类序列号的问题（#47）
+- [x] ⚠️ **不兼容变更:** `IStatisticsFunction.Sum` 由 `params ColumnMatrix[]` 改为 `params ColumnValue[]`，`IMathFunction` 多个方法的返回值由 `int` / `double` 统一为 `ColumnValue`。源码级兼容（现有公式无需修改即可编译），但二进制不兼容，升级后需重新编译
 
 * **2026.09.11** - v2.2.1
 - [x] 🔧 修复命令行工具包体超过 NuGet 250 MB 上限导致 2.2.0 未能发布的问题：CLI 仅保留 net8.0 并剔除原生 `.pdb`（库代码无变更）

--- a/README_EN.md
+++ b/README_EN.md
@@ -55,8 +55,21 @@ See [Chsword.Excel2Object.Cli/README.md](Chsword.Excel2Object.Cli/README.md).
 - [x] Support auto width column ✅ **New in v2.0.4**
 - [x] Support date/datetime/time formats in Excel ✅ **New in v2.0.4** - See [DateTimeFormats.md](DateTimeFormats.md)
 - [x] Formula columns referencing other sheets of the same workbook ✅ **New in v2.1.0** - See [ExcelFunctions.md](ExcelFunctions.md)
+- [x] Built-in formula function library ✅ **New in v2.3.0** - 334 Excel functions in 10 categories - See [ExcelFunctions.md](ExcelFunctions.md)
 
 ### Release Notes
+
+* **2026.09.11** - v2.3.0
+- [x] ✨ **NEW:** The built-in formula function library grew from 34 to **334** Excel functions in 10 categories: math and trigonometry (73), statistical (80), logical (11), lookup and reference (33), date and time (25), text (39), information (20), financial (21), engineering (20) and database (12). Information, financial, engineering and database are new categories, reached through `ExcelFunctions.Information`, `.Financial`, `.Engineering` and `.Database` - See [ExcelFunctions.md](ExcelFunctions.md)
+- [x] 🐛 Fixed functions Excel gained after 2007 showing `#NAME?` once the workbook was opened: xlsx stores them under a prefix (`_xlfn.IFS`, `_xlfn.STDEV.P`, and `_xlfn._xlws.` for `SORT` / `FILTER`), which is now added automatically; the already supported `DAYS` was affected
+- [x] 🐛 Fixed numbers in formulas being formatted with the current culture, so that `1.5` became `1,5` under `de-DE` and the formula no longer parsed; the invariant culture is used now
+- [x] 🐛 Fixed double quotes inside text literals not being escaped the way Excel wants them (`"` written as `""`)
+- [x] ✨ **NEW:** More plain C# can be written straight into a formula: `%` (MOD), `^` (power), `&&` / `||` / `!` (AND / OR / NOT), the conditional operator (IF), `Math.*`, `string` members (`ToUpper`, `Substring`, `Length`, `Contains`, ...; members whose Excel counterpart computes something else, such as `Math.Round` and `string.Trim`, are left unsupported - call the `ExcelFunctions` function explicitly instead), `DateTime` members and `AddDays` / `AddMonths` / `AddYears`, and `.HasValue` on nullable properties
+- [x] ✨ **NEW:** Formulas can use local variables the lambda captured and constant expressions such as `new DateTime(...)`; they are evaluated and written as literals instead of producing an invalid formula
+- [x] ✨ **IMPROVED:** Ranges (`c.Matrix(...)`, `c.Columns(...)`) convert implicitly wherever a single value is expected, so `SUM` and friends take cells and ranges in one call
+- [x] 🐛 Fixed cell styles from `[ExcelColumn]` being silently ignored: the style cache key never matched the branch that reads it, so `CellBold` / `CellFontColor` / `CellAlignment` and friends never reached the cell. Also fixed one column's `CellAlignment` being written to the workbook's default style, which dragged unrelated columns along with it (#47)
+- [x] 🐛 Fixed formula columns with `FormulaResultType = typeof(DateTime)` getting no date format, so Excel showed a serial number such as `46282.6` (#47)
+- [x] ⚠️ **BREAKING:** `IStatisticsFunction.Sum` takes `params ColumnValue[]` instead of `params ColumnMatrix[]`, and several `IMathFunction` members return `ColumnValue` instead of `int` / `double`. Source compatible - existing formulas still compile - but binary breaking, so recompile after upgrading
 
 * **2026.09.11** - v2.2.1
 - [x] 🔧 Fixed the command-line tool package exceeding NuGet's 250 MB limit, which kept 2.2.0 of the CLI from being published: net8.0 only and native `.pdb` files dropped (no library changes)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,14 +35,18 @@ excel2obj convert input.xlsx --output data.json --typed
 excel2obj generate-model input.xlsx --output Model.cs --class Model
 ```
 
-#### 3. 增强公式支持 ✅ 部分已完成（v2.1.0 / v2.2.0）
+#### 3. 增强公式支持 ✅ 部分已完成（v2.1.0 / v2.2.0 / v2.3.0）
 **优先级：中**
 
 - [x] 跨 sheet 引用与整列引用：`c.Sheet("Products").Columns("Name", "Price")` - 查看 [ExcelFunctions.md](ExcelFunctions.md)
 - [x] 通过模型属性引用列：`options.FormulaColumns.Add<Order>("Total", (c, m) => m.Price * m.Qty)`
 - [x] 按 Excel 运算符优先级自动补括号
-- [ ] 扩展内置函数库
+- [x] 扩展内置函数库：334 个 Excel 函数，分 10 类（数学/统计/逻辑/查找引用/日期时间/文本/信息/财务/工程/数据库），
+      Excel 2007 之后新增的函数按文件格式要求自动加 `_xlfn.` 前缀 - 查看 [ExcelFunctions.md](ExcelFunctions.md)
+- [x] 支持更复杂的 Excel 公式：`%`、`^`、`&&`/`||`/`!`、三元表达式，以及 `Math.*`、`string` 成员、
+      捕获的局部变量等普通 C# 写法直接翻译成对应的 Excel 函数
 - [ ] 支持自定义函数
+- [ ] 支持公式的动态计算
 
 #### 4. 支持 Excel 图表导入导出
 **优先级：低**
@@ -134,14 +138,19 @@ excel2obj convert input.xlsx --output data.json --typed
 excel2obj generate-model input.xlsx --output Model.cs --class Model
 ```
 
-#### 3. Enhanced Formula Support ✅ Partly done (v2.1.0 / v2.2.0)
+#### 3. Enhanced Formula Support ✅ Partly done (v2.1.0 / v2.2.0 / v2.3.0)
 **Priority: Medium**
 
 - [x] Cross-sheet and whole-column references: `c.Sheet("Products").Columns("Name", "Price")` - See [ExcelFunctions.md](ExcelFunctions.md)
 - [x] Referring to columns through model properties: `options.FormulaColumns.Add<Order>("Total", (c, m) => m.Price * m.Qty)`
 - [x] Parentheses inserted automatically to follow Excel operator precedence
-- [ ] Extend the built-in function library
+- [x] Extended built-in function library: 334 Excel functions in 10 categories (math, statistical, logical,
+      lookup, date and time, text, information, financial, engineering, database); functions Excel gained
+      after 2007 get the `_xlfn.` prefix the file format requires - see [ExcelFunctions.md](ExcelFunctions.md)
+- [x] More complex Excel formulas: `%`, `^`, `&&` / `||` / `!`, the conditional operator, plus plain C#
+      (`Math.*`, `string` members, captured variables) translated to the Excel function that does the same
 - [ ] Support custom functions
+- [ ] Support dynamic formula calculation
 
 #### 4. Support Excel Chart Import/Export
 **Priority: Low**


### PR DESCRIPTION
## 背景

公式列的翻译机制本身是通用的（`ExcelFunctions.X.Method(...)` → `METHOD(...)`），但函数清单几乎是空的：只声明了 **34 个**函数——统计类只有 `SUM`、逻辑类只有 `IF`、文本类只有 `FIND`/`ASC`，信息、财务、工程、数据库四大类完全缺失。常用的 `SUMIF`、`COUNTIF`、`AVERAGE`、`MAX`/`MIN`、`LEFT`/`MID`/`LEN`、`TEXT`、`HLOOKUP`、`OFFSET`、`EOMONTH`、`NETWORKDAYS` 都写不出来。

对应 ROADMAP 第 3 项「增强公式支持 - 扩展内置函数库」。

## 改动

### 函数库：34 → 334，10 个类别

| 类别 | 数量 | 入口 |
|---|---|---|
| 数学与三角 | 73 | `ExcelFunctions.Math` |
| 统计 | 80 | `.Statistics` |
| 逻辑 | 11 | `.Condition` |
| 查找与引用 | 33 | `.Reference` |
| 日期时间 | 25 | `.DateAndTime` |
| 文本 | 39 | `.Text` |
| 信息 | 20 | `.Information` ✨ |
| 财务 | 21 | `.Financial` ✨ |
| 工程 | 20 | `.Engineering` ✨ |
| 数据库 | 12 | `.Database` ✨ |

所有函数接口改为继承 `IExcelFunction`，`ExpressionConvert` 以此为判据，不再维护硬编码类型列表——新增分类只要声明接口即可被识别。`ExcelFunctionNameAttribute` 负责方法名拼不出来的名字（`STDEV.P`、`CEILING.MATH`、`ERROR.TYPE`）。

### 🐛 修复：Excel 2007 之后新增的函数打开显示 `#NAME?`

xlsx 格式要求这类函数存成 `_xlfn.IFS`、`_xlfn.STDEV.P`（`SORT`/`FILTER` 这两个 worksheet-only 的是 `_xlfn._xlws.`），Excel 显示时会去掉前缀。存裸名字会显示 `#NAME?` 而不是结果。现由属性标注并自动加前缀——**此前已支持的 `DAYS`（2013 新增）正受此影响**。

### 🐛 修复：字面量翻译

- 数字按当前区域性格式化：`de-DE` 下 `1.5` 写成 `1,5`，公式无法解析。改用不变区域性。
- 文本中的双引号未按 Excel 规则转义（`"` 需写成 `""`）。

### ✨ 更多普通 C# 可直接写进公式

`%`（MOD）、`^`（单元格上是乘幂，整数/布尔上是 BITXOR/XOR）、`&&` `||` `!`（AND/OR/NOT）、三元表达式（IF）、`System.Math`、`string` 成员（`ToUpper`/`Substring`/`Length`/`Contains`…）、`DateTime` 成员与 `Add*`、可空属性的 `.HasValue`。

lambda 捕获的局部变量和 `new DateTime(...)` 等常量表达式会求值后写成字面量（此前会生成无效公式）。编译结果按表达式节点缓存——公式列的表达式树逐行复用，不缓存的话 2000 行要 580ms，缓存后 3ms。

区间（`ColumnMatrix`）可隐式转 `ColumnValue`，`SUM` 等函数可混合传入单元格与区间。

## ⚠️ 不兼容变更

`IStatisticsFunction.Sum` 由 `params ColumnMatrix[]` 改为 `params ColumnValue[]`，`IMathFunction` 多个方法返回值由 `int`/`double` 统一为 `ColumnValue`。**源码级兼容**（现有公式无需修改即可编译），但二进制不兼容，升级后需重新编译。

## 验证

- **172 个测试通过**（新增 55 个），7 个目标框架构建干净
- 一个集成测试把 27 条新公式喂给 NPOI 的公式解析器确认可写入；另一个确认 `_xlfn.IFS` 真的以带前缀形式落盘；还有一个确认导入含未知函数的表不会抛异常
- 反射测试校验所有接口方法的函数名形如合法 Excel 函数名、带点的必须有属性标注、所有分类都挂在 `ExcelFunctions` 和 `IAllFunction` 上
- 实测 NPOI 解析器接受 120/122 个抽样函数名（`VAR.S`、`T.INV` 会被误判为 dotted range，加 `_xlfn.` 前缀后全部通过）

## 文档

`ExcelFunctions.md` 按接口重新生成（完整函数对照表 + C# 映射表 + 前缀说明），README/README_EN 补 v2.3.0 更新日志，ROADMAP 对应条目勾选，版本号 bump 到 2.3.0。

## 变基说明

本分支创建时 `main` 还在 `929b004`（v2.2.1），随后 #47 合入。已变基到最新 `main`，冲突两处，均已解决：

- `IMathFunction.cs` —— #47 给 `Fact` 补了 XML 注释，本 PR 重写了整个接口（`Fact` 已有 `/// <summary>FACT - factorial.</summary>`），取本 PR 版本
- `ROADMAP.md` —— #47 重排了「增强公式支持」小节并勾选了 v2.1.0 / v2.2.0 的条目，本 PR 把「扩展内置函数库」从未完成改为完成，两边条目已合并

变基后重新构建与全量测试：**187 个测试通过**（本 PR 55 个 + #47 新增 15 个 + 原有）。

v2.3.0 的更新日志同时补上了 #47 里两条尚未发布的用户可见修复（`[ExcelColumn]` 单元格样式被忽略、DateTime 公式列缺日期格式）——发布工作流是从 README 提取该版本的说明打 release notes 的，不写进去这两条会静默发布。

🤖 Generated with [Claude Code](https://claude.com/claude-code)