### PR TITLE
精简 CI/Release 工作流的重复构建

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -7,26 +7,43 @@ on:
     branches: [ main, master ]
 
 jobs:
+  # 决定这次跑几个平台：PR 上只用 ubuntu 换取快速反馈，push 到 main 时再跑全平台
+  # Pick the platforms for this run: ubuntu alone on a pull request for fast feedback,
+  # all three on a push to main
+  matrix-setup:
+    name: Select Platforms
+    runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.select.outputs.os }}
+    steps:
+    - name: Select platforms
+      id: select
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          echo 'os=["ubuntu-latest"]' >> $GITHUB_OUTPUT
+        else
+          echo 'os=["ubuntu-latest","windows-latest","macos-latest"]' >> $GITHUB_OUTPUT
+        fi
+
   build-and-test:
     name: Build and Test
+    needs: matrix-setup
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: ${{ fromJSON(needs.matrix-setup.outputs.os) }}
       fail-fast: false
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
 
+    # 10.0 的 SDK 可以编译 net472 / net6.0 / net8.0 / net9.0 的目标，测试只跑 net10.0
+    # The 10.0 SDK builds the net472 / net6.0 / net8.0 / net9.0 targets; the tests run on net10.0 only
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: |
-          6.0.x
-          8.0.x
-          9.0.x
-          10.0.x
+        dotnet-version: 10.0.x
 
     - name: Cache NuGet packages
       uses: actions/cache@v6
@@ -65,20 +82,18 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: |
-          6.0.x
-          8.0.x
-          9.0.x
-          10.0.x
+        dotnet-version: 10.0.x
 
-    - name: Restore dependencies
-      run: dotnet restore
-
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
+    - name: Cache NuGet packages
+      uses: actions/cache@v6
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
 
     - name: Pack
-      run: dotnet pack --configuration Release --no-build --output ./artifacts
+      run: dotnet pack --configuration Release --output ./artifacts
 
     - name: Upload NuGet package
       uses: actions/upload-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,13 +66,64 @@ jobs:
         fi
         echo "✓ 版本号一致性验证通过 / Version consistency validated"
 
+  # 要求这次提交的 .NET CI（ubuntu / windows / macOS 三平台）已经跑过且通过
+  # Require the .NET CI run for this commit - ubuntu / windows / macOS - to have passed
+  require-ci:
+    name: Require CI Success
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+
+    steps:
+    - name: Wait for the .NET CI run on this commit
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        SHA="${{ github.sha }}"
+        # CI 用时约 3 分钟；给它 15 分钟，足够覆盖排队和紧跟着 push 就打 tag 的情况
+        # CI takes about 3 minutes; 15 covers queueing and a tag pushed right after the commit
+        DEADLINE=$(( $(date +%s) + 15 * 60 ))
+
+        while :; do
+          RUN=$(gh api "repos/${{ github.repository }}/actions/workflows/dotnet-ci.yml/runs?head_sha=$SHA&per_page=1" \
+            --jq '.workflow_runs[0] // empty | "\(.status) \(.conclusion // "-") \(.html_url)"' 2>/dev/null || echo "")
+
+          STATUS=$(echo "$RUN" | cut -d' ' -f1)
+          CONCLUSION=$(echo "$RUN" | cut -d' ' -f2)
+          URL=$(echo "$RUN" | cut -d' ' -f3)
+
+          if [ "$STATUS" = "completed" ]; then
+            if [ "$CONCLUSION" = "success" ]; then
+              echo "✓ .NET CI 已通过 / .NET CI passed: $URL"
+              exit 0
+            fi
+            echo "✗ 该提交的 .NET CI 结论为 $CONCLUSION，不发布 / .NET CI concluded $CONCLUSION, not publishing"
+            echo "   $URL"
+            exit 1
+          fi
+
+          if [ $(date +%s) -ge $DEADLINE ]; then
+            if [ -z "$RUN" ]; then
+              echo "✗ 找不到该提交的 .NET CI run / No .NET CI run found for this commit ($SHA)"
+              echo "   请先把提交推到 main 让 CI 跑完再打 tag"
+              echo "   Push the commit to main and let CI finish before tagging"
+            else
+              echo "✗ 等待 .NET CI 超时 / Timed out waiting for .NET CI: $URL"
+            fi
+            exit 1
+          fi
+
+          echo "… 等待 .NET CI / waiting for .NET CI (${STATUS:-not started yet})"
+          sleep 20
+        done
+
   # 构建、测试并打包
   # tag 指向的提交已经由 .NET CI 在三个平台上测过，这里只在 ubuntu 上跑一遍作为发布前的闸门
   # The tagged commit was already tested on all three platforms by .NET CI, so this is a single
   # ubuntu run acting as the gate before publishing
   pack-nuget:
     name: Pack NuGet Package
-    needs: validate-version
+    needs: [validate-version, require-ci]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,34 +66,36 @@ jobs:
         fi
         echo "✓ 版本号一致性验证通过 / Version consistency validated"
 
-  # 构建和测试
-  build-and-test:
-    name: Build and Test
+  # 构建、测试并打包
+  # tag 指向的提交已经由 .NET CI 在三个平台上测过，这里只在 ubuntu 上跑一遍作为发布前的闸门
+  # The tagged commit was already tested on all three platforms by .NET CI, so this is a single
+  # ubuntu run acting as the gate before publishing
+  pack-nuget:
+    name: Pack NuGet Package
     needs: validate-version
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest]
-      fail-fast: false
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
 
+    # 10.0 的 SDK 可以编译 net472 / net6.0 / net8.0 / net9.0 的目标，测试只跑 net10.0
+    # The 10.0 SDK builds the net472 / net6.0 / net8.0 / net9.0 targets; the tests run on net10.0 only
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v6
       with:
-        dotnet-version: |
-          6.0.x
-          8.0.x
-          9.0.x
-          10.0.x
+        dotnet-version: 10.0.x
 
-    - name: Restore dependencies
-      run: dotnet restore
+    - name: Cache NuGet packages
+      uses: actions/cache@v6
+      with:
+        path: ~/.nuget/packages
+        key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+        restore-keys: |
+          ${{ runner.os }}-nuget-
 
     - name: Build
-      run: dotnet build --configuration Release --no-restore
+      run: dotnet build --configuration Release
 
     - name: Test
       run: dotnet test --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx"
@@ -102,33 +104,8 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v7
       with:
-        name: test-results-${{ matrix.os }}
+        name: test-results
         path: "**/test-results.trx"
-
-  # 打包 NuGet 包
-  pack-nuget:
-    name: Pack NuGet Package
-    needs: [validate-version, build-and-test]
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v7
-
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v6
-      with:
-        dotnet-version: |
-          6.0.x
-          8.0.x
-          9.0.x
-          10.0.x
-
-    - name: Restore dependencies
-      run: dotnet restore
-
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
 
     - name: Pack NuGet package
       run: dotnet pack --configuration Release --no-build --output ./artifacts
@@ -173,7 +150,7 @@ jobs:
   # 创建 GitHub Release
   create-release:
     name: Create GitHub Release
-    needs: [validate-version, build-and-test, pack-nuget]
+    needs: [validate-version, pack-nuget]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## 背景

之前每次 PR 都在三个平台跑同一批测试（测试项目只有 net10.0 一个 TFM），打 tag 时 release 工作流又把已经测过的提交重跑一遍矩阵；两个工作流都装了 4 个 SDK，release 还漏了 NuGet 缓存。

## 变更

- **PR 只跑 ubuntu**（60s，此前最慢的 windows 143s）；push 到 main 仍跑 ubuntu / windows / macOS 三平台，net472 的真实验证保留在 main 路径上。由一个 `matrix-setup` job 输出平台列表实现
- **release 工作流去掉独立的 build-and-test 矩阵**：tag 指向的提交刚由 .NET CI 测过，改为单个 ubuntu job 完成 build → test → pack，既少 2 个 job 又不会发布未经测试的提交
- **只装 10.0 SDK**：10 的 SDK 能编译 net472 / net6.0 / net8.0 / net9.0 的目标，测试只跑 net10.0，不需要旧 runtime
- **NuGet 缓存**补到 release 与 packaging job；打包不再 restore + build + pack 三遍

## 验证

本机只装了 10.0 SDK，按 release 工作流同样的步骤跑通：全部 TFM 构建 0 警告、266 个测试通过、两个包正常生成（库 299K，CLI 79M，在 NuGet 250MB 上限内）。这个 PR 自身会验证新的 PR 路径只起一个 ubuntu job。

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)