### PR TITLE
修复打包 job：pack 前先 build

### DIFF
--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -92,8 +92,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-nuget-
 
+    # 先 build 再 pack --no-build：库是多目标的，而 CLI 只引用它的 net8.0，
+    # 裸 dotnet pack 只会构建那一个 TFM，打包时其余的输出就不存在（NU5026）
+    # Build first, then pack --no-build: the library multi-targets while the CLI references only its
+    # net8.0, so a bare dotnet pack builds that one TFM and packing misses the rest (NU5026)
+    - name: Build
+      run: dotnet build --configuration Release
+
     - name: Pack
-      run: dotnet pack --configuration Release --output ./artifacts
+      run: dotnet pack --configuration Release --no-build --output ./artifacts
 
     - name: Upload NuGet package
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
## 问题

#50 把 CI 打包 job 的 `build` + `pack --no-build` 合并成了一步 `dotnet pack`，合并到 main 后打包失败：

```
error NU5026: The file '.../bin/Release/net10.0/Chsword.Excel2Object.dll' to be packed was not found on disk.
```

解决方案级的 `dotnet pack` 只把库构建成 CLI 引用的那一个 TFM（net8.0），库本身是多目标的，打包时其余 TFM 的输出不存在。本地清空 bin/obj 后可稳定复现。

## 修复

打包 job 改回 `dotnet build` + `dotnet pack --no-build`，与 release 工作流一致（那条链本来就是对的，没有受影响）。本地按同样顺序验证：全部 TFM 构建通过，两个包正常生成。

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)