### PR TITLE
冻结首行、自动筛选与数据验证下拉 (v2.5.0)

### DIFF
--- a/Chsword.Excel2Object.Tests/DropdownTest.cs
+++ b/Chsword.Excel2Object.Tests/DropdownTest.cs
@@ -98,8 +98,9 @@ public class DropdownTest : BaseExcelTest
         {
             var workbook = Export(excelType, options => options.Dropdowns["状态"] = many);
             var validation = workbook.GetSheetAt(0).GetDataValidations().Single();
-            Assert.AreEqual($"{ListSheetName}!$A$1:$A$60", validation.ValidationConstraint.Formula1,
-                excelType.ToString());
+            Assert.AreEqual("_excel2object_list1", validation.ValidationConstraint.Formula1, excelType.ToString());
+            Assert.AreEqual($"{ListSheetName}!$A$1:$A$60",
+                workbook.GetName("_excel2object_list1").RefersToFormula, excelType.ToString());
 
             var listSheet = workbook.GetSheet(ListSheetName);
             Assert.AreEqual(SheetVisibility.Hidden, workbook.GetSheetVisibility(workbook.GetSheetIndex(listSheet)),
@@ -117,7 +118,8 @@ public class DropdownTest : BaseExcelTest
         var workbook = Export(ExcelType.Xlsx, options => options.Dropdowns["状态"] = values);
 
         Assert.AreEqual($"{ListSheetName}!$A$1:$A$2",
-            workbook.GetSheetAt(0).GetDataValidations().Single().ValidationConstraint.Formula1);
+            workbook.GetName(workbook.GetSheetAt(0).GetDataValidations().Single().ValidationConstraint.Formula1)
+                .RefersToFormula);
         Assert.AreEqual("甲, 乙", workbook.GetSheet(ListSheetName).GetRow(0).GetCell(0).StringCellValue);
     }
 
@@ -129,7 +131,8 @@ public class DropdownTest : BaseExcelTest
         var workbook = Export(ExcelType.Xlsx, options => options.Dropdowns["状态"] = values);
 
         Assert.AreEqual($"{ListSheetName}!$A$1:$A$2",
-            workbook.GetSheetAt(0).GetDataValidations().Single().ValidationConstraint.Formula1);
+            workbook.GetName(workbook.GetSheetAt(0).GetDataValidations().Single().ValidationConstraint.Formula1)
+                .RefersToFormula);
         Assert.AreEqual("14\" 屏", workbook.GetSheet(ListSheetName).GetRow(0).GetCell(0).StringCellValue);
     }
 
@@ -155,7 +158,8 @@ public class DropdownTest : BaseExcelTest
 
         var back = WorkbookFactory.Create(new MemoryStream(bytes));
         Assert.AreEqual($"{ListSheetName}2!$A$1:$A$60",
-            back.GetSheet("数据").GetDataValidations().Single().ValidationConstraint.Formula1);
+            back.GetName(back.GetSheet("数据").GetDataValidations().Single().ValidationConstraint.Formula1)
+                .RefersToFormula);
         Assert.AreEqual("我的数据", back.GetSheet(ListSheetName).GetRow(0).GetCell(0).StringCellValue);
         Assert.AreEqual("取值000", back.GetSheet(ListSheetName + "2").GetRow(0).GetCell(0).StringCellValue);
     }
@@ -189,10 +193,10 @@ public class DropdownTest : BaseExcelTest
             options.Dropdowns["状态"] = second;
         });
 
-        var formulas = workbook.GetSheetAt(0).GetDataValidations()
-            .Select(v => v.ValidationConstraint.Formula1).ToArray();
+        var ranges = workbook.GetSheetAt(0).GetDataValidations()
+            .Select(v => workbook.GetName(v.ValidationConstraint.Formula1).RefersToFormula).ToArray();
         CollectionAssert.AreEquivalent(
-            new[] {$"{ListSheetName}!$A$1:$A$60", $"{ListSheetName}!$B$1:$B$70"}, formulas);
+            new[] {$"{ListSheetName}!$A$1:$A$60", $"{ListSheetName}!$B$1:$B$70"}, ranges);
 
         var listSheet = workbook.GetSheet(ListSheetName);
         Assert.AreEqual("甲000", listSheet.GetRow(0).GetCell(0).StringCellValue);
@@ -200,6 +204,41 @@ public class DropdownTest : BaseExcelTest
         // the shorter list ends where it ends; the longer one keeps going on its own
         Assert.IsNull(listSheet.GetRow(65).GetCell(0));
         Assert.AreEqual("乙065", listSheet.GetRow(65).GetCell(1).StringCellValue);
+    }
+
+    /// <summary>
+    ///     Excel counts the quotes it wraps the inline list in, so the last list that still fits is two
+    ///     characters shorter than the limit itself.
+    /// </summary>
+    [DataTestMethod]
+    [DataRow(253, true)]
+    [DataRow(254, false)]
+    public void TheInlineListStopsAtWhatExcelHolds(int joinedLength, bool inline)
+    {
+        // two values, so the join adds one comma
+        var first = new string('a', joinedLength / 2);
+        var second = new string('b', joinedLength - 1 - first.Length);
+        var values = new[] {first, second};
+        Assert.AreEqual(joinedLength, string.Join(",", values).Length);
+
+        var validation = Export(ExcelType.Xlsx, options => options.Dropdowns["状态"] = values)
+            .GetSheetAt(0).GetDataValidations().Single();
+
+        if (inline)
+            CollectionAssert.AreEqual(values, validation.ValidationConstraint.ExplicitListValues);
+        else
+            Assert.AreEqual("_excel2object_list1", validation.ValidationConstraint.Formula1);
+    }
+
+    /// <summary>A list Excel cannot show an empty entry in should say so, not throw a NullReference.</summary>
+    [TestMethod]
+    public void ANullValueIsRejectedByName()
+    {
+        var e = Assert.ThrowsException<Excel2ObjectException>(() =>
+            Export(ExcelType.Xlsx, options => options.Dropdowns["状态"] = new[] {"启用", null!}));
+
+        StringAssert.Contains(e.Message, "状态");
+        StringAssert.Contains(e.Message, "index 1");
     }
 
     /// <summary>The values a dropdown allows still import as the values they are.</summary>

--- a/Chsword.Excel2Object.Tests/DropdownTest.cs
+++ b/Chsword.Excel2Object.Tests/DropdownTest.cs
@@ -121,6 +121,61 @@ public class DropdownTest : BaseExcelTest
         Assert.AreEqual("甲, 乙", workbook.GetSheet(ListSheetName).GetRow(0).GetCell(0).StringCellValue);
     }
 
+    /// <summary>A quote cannot go inline either - Excel ends the list literal at it.</summary>
+    [TestMethod]
+    public void AValueWithAQuoteMovesToAHiddenSheet()
+    {
+        var values = new[] {"14\" 屏", "15 寸"};
+        var workbook = Export(ExcelType.Xlsx, options => options.Dropdowns["状态"] = values);
+
+        Assert.AreEqual($"{ListSheetName}!$A$1:$A$2",
+            workbook.GetSheetAt(0).GetDataValidations().Single().ValidationConstraint.Formula1);
+        Assert.AreEqual("14\" 屏", workbook.GetSheet(ListSheetName).GetRow(0).GetCell(0).StringCellValue);
+    }
+
+    /// <summary>
+    ///     A sheet of that name the workbook already owns is left alone - the values go to a free name
+    ///     instead of into someone else's data.
+    /// </summary>
+    [TestMethod]
+    public void AVisibleSheetOfTheSameNameIsNotWrittenInto()
+    {
+        var workbook = new NPOI.XSSF.UserModel.XSSFWorkbook();
+        var mine = workbook.CreateSheet(ListSheetName);
+        mine.CreateRow(0).CreateCell(0).SetCellValue("我的数据");
+        var stream = new MemoryStream();
+        workbook.Write(stream, true);
+
+        var many = Enumerable.Range(0, 60).Select(i => $"取值{i:D3}").ToArray();
+        var bytes = ExcelHelper.AppendObjectToExcelBytes(stream.ToArray(), Rows, options =>
+        {
+            options.SheetTitle = "数据";
+            options.Dropdowns["状态"] = many;
+        })!;
+
+        var back = WorkbookFactory.Create(new MemoryStream(bytes));
+        Assert.AreEqual($"{ListSheetName}2!$A$1:$A$60",
+            back.GetSheet("数据").GetDataValidations().Single().ValidationConstraint.Formula1);
+        Assert.AreEqual("我的数据", back.GetSheet(ListSheetName).GetRow(0).GetCell(0).StringCellValue);
+        Assert.AreEqual("取值000", back.GetSheet(ListSheetName + "2").GetRow(0).GetCell(0).StringCellValue);
+    }
+
+    /// <summary>The freeze and the filter reach an appended sheet through the same options.</summary>
+    [TestMethod]
+    public void AppendTakesOptions()
+    {
+        var first = new ExcelExporter().ObjectToExcelBytes(Rows, options => options.ExcelType = ExcelType.Xlsx)!;
+        var bytes = ExcelHelper.AppendObjectToExcelBytes(first, Rows, options =>
+        {
+            options.SheetTitle = "第二页";
+            options.FreezeHeader = true;
+        })!;
+
+        var workbook = WorkbookFactory.Create(new MemoryStream(bytes));
+        Assert.IsNotNull(workbook.GetSheet("第二页").PaneInformation);
+        Assert.IsNull(workbook.GetSheetAt(0).PaneInformation);
+    }
+
     /// <summary>Two long lists share the hidden sheet, each in its own column.</summary>
     [TestMethod]
     public void EachLongListGetsItsOwnColumnOnTheHiddenSheet()

--- a/Chsword.Excel2Object.Tests/DropdownTest.cs
+++ b/Chsword.Excel2Object.Tests/DropdownTest.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Chsword.Excel2Object.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NPOI.SS.UserModel;
+
+namespace Chsword.Excel2Object.Tests;
+
+/// <summary>
+///     A column can limit its cells to a list of values; Excel shows that list as a dropdown.
+/// </summary>
+[TestClass]
+public class DropdownTest : BaseExcelTest
+{
+    private const string ListSheetName = "_excel2object_lists";
+
+    public class Model
+    {
+        [ExcelTitle("城市")] public string City { get; set; } = "北京";
+
+        [ExcelColumn("状态", Dropdown = new[] {"启用", "停用", "待审"})]
+        public string Status { get; set; } = "启用";
+    }
+
+    private static readonly List<Model> Rows = new() {new(), new()};
+
+    private static IWorkbook Export(ExcelType excelType, Action<ExcelExporterOptions>? configure = null,
+        List<Model>? rows = null)
+    {
+        var bytes = new ExcelExporter().ObjectToExcelBytes(rows ?? Rows, options =>
+        {
+            options.ExcelType = excelType;
+            configure?.Invoke(options);
+        });
+        Assert.IsNotNull(bytes);
+        return WorkbookFactory.Create(new MemoryStream(bytes));
+    }
+
+    [TestMethod]
+    public void TheAttributesValuesBecomeADropdownInBothFileFormats()
+    {
+        foreach (var excelType in new[] {ExcelType.Xlsx, ExcelType.Xls})
+        {
+            var sheet = Export(excelType).GetSheetAt(0);
+            var validations = sheet.GetDataValidations();
+            Assert.AreEqual(1, validations.Count, excelType.ToString());
+
+            var validation = validations[0];
+            CollectionAssert.AreEqual(new[] {"启用", "停用", "待审"},
+                validation.ValidationConstraint.ExplicitListValues, excelType.ToString());
+            // the header keeps its own value, the dropdown belongs to the rows under it
+            Assert.AreEqual("B2:B3", validation.Regions.CellRangeAddresses[0].FormatAsString(),
+                excelType.ToString());
+        }
+    }
+
+    /// <summary>Values only known at runtime come through the options, and win over the attribute.</summary>
+    [TestMethod]
+    public void OptionsDropdownsOverrideTheAttribute()
+    {
+        var runtime = new[] {"甲", "乙"};
+        var sheet = Export(ExcelType.Xlsx, options => options.Dropdowns["状态"] = runtime).GetSheetAt(0);
+
+        var validation = sheet.GetDataValidations().Single();
+        CollectionAssert.AreEqual(runtime, validation.ValidationConstraint.ExplicitListValues);
+    }
+
+    /// <summary>A column that declares none has no validation of its own.</summary>
+    [TestMethod]
+    public void AColumnWithoutValuesGetsNoDropdown()
+    {
+        var sheet = Export(ExcelType.Xlsx).GetSheetAt(0);
+        Assert.AreEqual(1, sheet.GetDataValidations().Count);
+        Assert.AreEqual(1, sheet.GetDataValidations()[0].Regions.CellRangeAddresses[0].FirstColumn);
+    }
+
+    /// <summary>An empty export is a template, and a template needs its dropdown on the first row.</summary>
+    [TestMethod]
+    public void AnEmptySheetStillGetsTheDropdown()
+    {
+        var sheet = Export(ExcelType.Xlsx, rows: new List<Model>()).GetSheetAt(0);
+        Assert.AreEqual("B2", sheet.GetDataValidations().Single().Regions.CellRangeAddresses[0].FormatAsString());
+    }
+
+    /// <summary>
+    ///     Excel holds at most 255 characters inline, and splits the list on commas. A longer list, or one
+    ///     with a comma in it, goes to a hidden sheet the dropdown reads from - xls would otherwise throw.
+    /// </summary>
+    [TestMethod]
+    public void ALongListMovesToAHiddenSheet()
+    {
+        var many = Enumerable.Range(0, 60).Select(i => $"取值{i:D3}").ToArray();
+        Assert.IsTrue(string.Join(",", many).Length > 255);
+
+        foreach (var excelType in new[] {ExcelType.Xlsx, ExcelType.Xls})
+        {
+            var workbook = Export(excelType, options => options.Dropdowns["状态"] = many);
+            var validation = workbook.GetSheetAt(0).GetDataValidations().Single();
+            Assert.AreEqual($"{ListSheetName}!$A$1:$A$60", validation.ValidationConstraint.Formula1,
+                excelType.ToString());
+
+            var listSheet = workbook.GetSheet(ListSheetName);
+            Assert.AreEqual(SheetVisibility.Hidden, workbook.GetSheetVisibility(workbook.GetSheetIndex(listSheet)),
+                excelType.ToString());
+            Assert.AreEqual("取值000", listSheet.GetRow(0).GetCell(0).StringCellValue, excelType.ToString());
+            Assert.AreEqual("取值059", listSheet.GetRow(59).GetCell(0).StringCellValue, excelType.ToString());
+        }
+    }
+
+    /// <summary>A value carrying a comma cannot go inline either - Excel would read it as two values.</summary>
+    [TestMethod]
+    public void AValueWithACommaMovesToAHiddenSheet()
+    {
+        var values = new[] {"甲, 乙", "丙"};
+        var workbook = Export(ExcelType.Xlsx, options => options.Dropdowns["状态"] = values);
+
+        Assert.AreEqual($"{ListSheetName}!$A$1:$A$2",
+            workbook.GetSheetAt(0).GetDataValidations().Single().ValidationConstraint.Formula1);
+        Assert.AreEqual("甲, 乙", workbook.GetSheet(ListSheetName).GetRow(0).GetCell(0).StringCellValue);
+    }
+
+    /// <summary>Two long lists share the hidden sheet, each in its own column.</summary>
+    [TestMethod]
+    public void EachLongListGetsItsOwnColumnOnTheHiddenSheet()
+    {
+        var first = Enumerable.Range(0, 60).Select(i => $"甲{i:D3}").ToArray();
+        var second = Enumerable.Range(0, 70).Select(i => $"乙{i:D3}").ToArray();
+
+        var workbook = Export(ExcelType.Xlsx, options =>
+        {
+            options.Dropdowns["城市"] = first;
+            options.Dropdowns["状态"] = second;
+        });
+
+        var formulas = workbook.GetSheetAt(0).GetDataValidations()
+            .Select(v => v.ValidationConstraint.Formula1).ToArray();
+        CollectionAssert.AreEquivalent(
+            new[] {$"{ListSheetName}!$A$1:$A$60", $"{ListSheetName}!$B$1:$B$70"}, formulas);
+
+        var listSheet = workbook.GetSheet(ListSheetName);
+        Assert.AreEqual("甲000", listSheet.GetRow(0).GetCell(0).StringCellValue);
+        Assert.AreEqual("乙000", listSheet.GetRow(0).GetCell(1).StringCellValue);
+        // the shorter list ends where it ends; the longer one keeps going on its own
+        Assert.IsNull(listSheet.GetRow(65).GetCell(0));
+        Assert.AreEqual("乙065", listSheet.GetRow(65).GetCell(1).StringCellValue);
+    }
+
+    /// <summary>The values a dropdown allows still import as the values they are.</summary>
+    [TestMethod]
+    public void ADropdownColumnRoundTrips()
+    {
+        var bytes = new ExcelExporter().ObjectToExcelBytes(Rows, options => options.ExcelType = ExcelType.Xlsx)!;
+        var back = ExcelHelper.ExcelToObject<Model>(bytes).ToArray();
+
+        Assert.AreEqual(2, back.Length);
+        Assert.AreEqual("启用", back[0].Status);
+    }
+}

--- a/Chsword.Excel2Object.Tests/HeaderViewTest.cs
+++ b/Chsword.Excel2Object.Tests/HeaderViewTest.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.IO;
+using Chsword.Excel2Object.Options;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NPOI.SS.UserModel;
+
+namespace Chsword.Excel2Object.Tests;
+
+/// <summary>
+///     A long sheet is only usable when its header stays in view and can filter the rows below it.
+/// </summary>
+[TestClass]
+public class HeaderViewTest : BaseExcelTest
+{
+    public class Model
+    {
+        [ExcelTitle("城市")] public string City { get; set; } = "";
+        [ExcelTitle("人数")] public int Count { get; set; }
+    }
+
+    private static readonly List<Model> Rows = new()
+    {
+        new() {City = "北京", Count = 3},
+        new() {City = "上海", Count = 5}
+    };
+
+    private static IWorkbook Export(ExcelType excelType, System.Action<ExcelExporterOptions> configure,
+        List<Model>? rows = null)
+    {
+        var bytes = new ExcelExporter().ObjectToExcelBytes(rows ?? Rows, options =>
+        {
+            options.ExcelType = excelType;
+            configure(options);
+        });
+        Assert.IsNotNull(bytes);
+        return WorkbookFactory.Create(new MemoryStream(bytes));
+    }
+
+    [TestMethod]
+    public void TheHeaderRowIsFrozenInBothFileFormats()
+    {
+        foreach (var excelType in new[] {ExcelType.Xlsx, ExcelType.Xls})
+        {
+            var pane = Export(excelType, options => options.FreezeHeader = true).GetSheetAt(0).PaneInformation;
+            Assert.IsNotNull(pane, excelType.ToString());
+            Assert.AreEqual(1, pane.HorizontalSplitPosition, excelType.ToString());
+            Assert.AreEqual(1, pane.HorizontalSplitTopRow, excelType.ToString());
+            Assert.AreEqual(0, pane.VerticalSplitPosition, excelType.ToString());
+        }
+    }
+
+    /// <summary>The filter covers the header and every row written under it.</summary>
+    [TestMethod]
+    public void TheHeaderRowCarriesTheFilterOverTheData()
+    {
+        foreach (var excelType in new[] {ExcelType.Xlsx, ExcelType.Xls})
+        {
+            var workbook = Export(excelType, options => options.AutoFilter = true);
+            Assert.AreEqual(1, workbook.NumberOfNames, excelType.ToString());
+            Assert.AreEqual("Sheet1!$A$1:$B$3", workbook.GetNameAt(0).RefersToFormula, excelType.ToString());
+        }
+    }
+
+    /// <summary>Without rows the dropdowns still belong on the header.</summary>
+    [TestMethod]
+    public void AnEmptySheetStillGetsItsFilter()
+    {
+        var workbook = Export(ExcelType.Xlsx, options => options.AutoFilter = true, new List<Model>());
+        Assert.AreEqual("Sheet1!$A$1:$B$1", workbook.GetNameAt(0).RefersToFormula);
+    }
+
+    [TestMethod]
+    public void NeitherIsOnByDefault()
+    {
+        foreach (var excelType in new[] {ExcelType.Xlsx, ExcelType.Xls})
+        {
+            var workbook = Export(excelType, _ => { });
+            Assert.IsNull(workbook.GetSheetAt(0).PaneInformation, excelType.ToString());
+            Assert.AreEqual(0, workbook.NumberOfNames, excelType.ToString());
+        }
+    }
+
+    /// <summary>An appended sheet gets the same treatment, and the sheet already there is left alone.</summary>
+    [TestMethod]
+    public void AnAppendedSheetIsFrozenAndFilteredOnItsOwn()
+    {
+        var first = new ExcelExporter().ObjectToExcelBytes(Rows, options => options.ExcelType = ExcelType.Xlsx)!;
+        var bytes = new ExcelExporter().ObjectToExcelBytes(Rows, options =>
+        {
+            options.ExcelType = ExcelType.Xlsx;
+            options.SourceExcelBytes = first;
+            options.SheetTitle = "第二页";
+            options.FreezeHeader = true;
+            options.AutoFilter = true;
+        })!;
+
+        var workbook = WorkbookFactory.Create(new MemoryStream(bytes));
+        Assert.IsNotNull(workbook.GetSheet("第二页").PaneInformation);
+        Assert.IsNull(workbook.GetSheetAt(0).PaneInformation);
+        Assert.AreEqual("第二页!$A$1:$B$3", workbook.GetNameAt(0).RefersToFormula);
+    }
+}

--- a/Chsword.Excel2Object/Chsword.Excel2Object.csproj
+++ b/Chsword.Excel2Object/Chsword.Excel2Object.csproj
@@ -13,7 +13,7 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Product>Chsword.Excel2Object Library</Product>
 		<Authors>Zou Jian</Authors>
-		<Version>2.4.0</Version>
+		<Version>2.5.0</Version>
 		<Copyright>Copyright ? 2014-2025</Copyright>
 		<PackageProjectUrl>https://github.com/chsword/Excel2Object/</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Chsword.Excel2Object/ExcelColumnAttribute.cs
+++ b/Chsword.Excel2Object/ExcelColumnAttribute.cs
@@ -80,6 +80,18 @@ public class ExcelColumnAttribute : ExcelTitleAttribute, IExcelHeaderStyle, IExc
     /// </summary>
     public string? Format { get; set; }
 
+    /// <summary>
+    /// Gets or sets the values this column's cells are limited to. Excel shows them as a dropdown and
+    /// rejects anything else: <c>[ExcelColumn("状态", Dropdown = new[] {"启用", "停用"})]</c>.
+    /// <para>
+    /// A list Excel cannot hold inline - over 255 characters in total, or a value carrying a comma or a
+    /// quote - is written to a hidden sheet the dropdown then reads from, which works the same way in
+    /// Excel. For values only known at runtime use <see cref="Options.ExcelExporterOptions.Dropdowns"/>,
+    /// which takes precedence over this one.
+    /// </para>
+    /// </summary>
+    public string[]? Dropdown { get; set; }
+
     // Header
 
     /// <summary>

--- a/Chsword.Excel2Object/ExcelExporter.cs
+++ b/Chsword.Excel2Object/ExcelExporter.cs
@@ -18,9 +18,15 @@ public class ExcelExporter
     public byte[]? AppendObjectToExcelBytes<TModel>(byte[] sourceExcelBytes, IEnumerable<TModel> data,
         string sheetTitle)
     {
+        return AppendObjectToExcelBytes(sourceExcelBytes, data, options => options.SheetTitle = sheetTitle);
+    }
+
+    public byte[]? AppendObjectToExcelBytes<TModel>(byte[] sourceExcelBytes, IEnumerable<TModel> data,
+        Action<ExcelExporterOptions> optionsAction)
+    {
         return ObjectToExcelBytes(data, options =>
         {
-            options.SheetTitle = sheetTitle;
+            optionsAction(options);
             options.SourceExcelBytes = sourceExcelBytes;
         });
     }

--- a/Chsword.Excel2Object/ExcelExporter.cs
+++ b/Chsword.Excel2Object/ExcelExporter.cs
@@ -152,6 +152,7 @@ public class ExcelExporter
                 }
 
                 ApplyHeaderView(sheet, options, columns.Length, rowNumber - 1);
+                DropdownValidation.Apply(sheet, columns, rowNumber - 1);
             }
 
         return ToBytes(workbook);

--- a/Chsword.Excel2Object/ExcelExporter.cs
+++ b/Chsword.Excel2Object/ExcelExporter.cs
@@ -177,7 +177,9 @@ public class ExcelExporter
         // the range covers the header even when no row followed it, so the dropdowns are there either way
         sheet.SetAutoFilter(new CellRangeAddress(ExcelConstants.DefaultHeaderRowIndex,
             Math.Max(lastRowIndex, ExcelConstants.DefaultHeaderRowIndex), 0, columnCount - 1));
-    }    private static bool IsNumeric(Type type)
+    }
+
+    private static bool IsNumeric(Type type)
     {
         return type == typeof(int) || type == typeof(long) || type == typeof(double) || type == typeof(decimal) ||
                type == typeof(float) || type == typeof(short) || type == typeof(byte) || type == typeof(uint) ||

--- a/Chsword.Excel2Object/ExcelExporter.cs
+++ b/Chsword.Excel2Object/ExcelExporter.cs
@@ -7,6 +7,7 @@ using Chsword.Excel2Object.Styles;
 using NPOI.HSSF.UserModel;
 using NPOI.SS.Formula;
 using NPOI.SS.UserModel;
+using NPOI.SS.Util;
 using NPOI.XSSF.UserModel;
 using HorizontalAlignment = Chsword.Excel2Object.Styles.HorizontalAlignment;
 
@@ -149,9 +150,26 @@ public class ExcelExporter
                         SetCellValue(options, column, cell, raw, val, columnTitles, sheetColumnsResolver, cellStyleDict);
                     }
                 }
+
+                ApplyHeaderView(sheet, options, columns.Length, rowNumber - 1);
             }
 
         return ToBytes(workbook);
+    }
+
+    /// <summary>
+    ///     Keeps the header usable on a long sheet: frozen in view while scrolling, and carrying Excel's
+    ///     filter dropdowns.
+    /// </summary>
+    private static void ApplyHeaderView(ISheet sheet, ExcelExporterOptions options, int columnCount, int lastRowIndex)
+    {
+        if (options.FreezeHeader)
+            sheet.CreateFreezePane(0, ExcelConstants.DefaultDataStartRowIndex);
+
+        if (!options.AutoFilter || columnCount == 0) return;
+        // the range covers the header even when no row followed it, so the dropdowns are there either way
+        sheet.SetAutoFilter(new CellRangeAddress(ExcelConstants.DefaultHeaderRowIndex,
+            Math.Max(lastRowIndex, ExcelConstants.DefaultHeaderRowIndex), 0, columnCount - 1));
     }    private static bool IsNumeric(Type type)
     {
         return type == typeof(int) || type == typeof(long) || type == typeof(double) || type == typeof(decimal) ||

--- a/Chsword.Excel2Object/ExcelHelper.cs
+++ b/Chsword.Excel2Object/ExcelHelper.cs
@@ -12,6 +12,13 @@ public static class ExcelHelper
         return excelExporter.AppendObjectToExcelBytes(sourceExcelBytes, data, sheetTitle);
     }
 
+    public static byte[]? AppendObjectToExcelBytes<TModel>(byte[] sourceExcelBytes, IEnumerable<TModel> data,
+        Action<ExcelExporterOptions> optionsAction)
+    {
+        var excelExporter = new ExcelExporter();
+        return excelExporter.AppendObjectToExcelBytes(sourceExcelBytes, data, optionsAction);
+    }
+
     /// <summary>
     ///     convert a excel file(bytes) to IEnumerable of TModel
     /// </summary>

--- a/Chsword.Excel2Object/Internal/DropdownValidation.cs
+++ b/Chsword.Excel2Object/Internal/DropdownValidation.cs
@@ -1,0 +1,82 @@
+using NPOI.SS.UserModel;
+using NPOI.SS.Util;
+
+namespace Chsword.Excel2Object.Internal;
+
+/// <summary>
+///     Writes the dropdown a column declares - Excel's list validation - over the rows of that column.
+/// </summary>
+/// <remarks>
+///     A short list is written into the validation itself. Excel only accepts 255 characters there
+///     (and splits the list on commas), so a longer list, or one whose values carry a comma or a quote,
+///     is written into a hidden sheet the validation then points at.
+/// </remarks>
+internal static class DropdownValidation
+{
+    /// <summary>The hidden sheet the long lists live on.</summary>
+    private const string ListSheetName = "_excel2object_lists";
+
+    /// <summary>What Excel accepts inside a list validation, commas and quotes included.</summary>
+    private const int InlineLimit = 255;
+
+    public static void Apply(ISheet sheet, ExcelColumn[] columns, int lastDataRowIndex)
+    {
+        // an export with no rows still gets its dropdown, so a template can be filled in
+        var lastRow = Math.Max(lastDataRowIndex, ExcelConstants.DefaultDataStartRowIndex);
+        var helper = sheet.GetDataValidationHelper();
+
+        for (var i = 0; i < columns.Length; i++)
+        {
+            var values = columns[i].Dropdown;
+            if (values == null || values.Length == 0) continue;
+
+            var constraint = FitsInline(values)
+                ? helper.CreateExplicitListConstraint(values)
+                : helper.CreateFormulaListConstraint(WriteToListSheet(sheet.Workbook, values));
+
+            var validation = helper.CreateValidation(constraint,
+                new CellRangeAddressList(ExcelConstants.DefaultDataStartRowIndex, lastRow, i, i));
+            // xlsx leaves the error box off unless it is asked for, and a dropdown that accepts
+            // anything typed over it is not much of a dropdown
+            validation.ShowErrorBox = true;
+            sheet.AddValidationData(validation);
+        }
+    }
+
+    private static bool FitsInline(string[] values)
+    {
+        var length = values.Length - 1; // the commas between them
+        foreach (var value in values)
+        {
+            if (value.IndexOf(',') >= 0 || value.IndexOf('"') >= 0) return false;
+            length += value.Length;
+        }
+
+        return length <= InlineLimit;
+    }
+
+    /// <summary>Puts the values in their own column on the hidden sheet and returns the range.</summary>
+    private static string WriteToListSheet(IWorkbook workbook, string[] values)
+    {
+        var sheet = workbook.GetSheet(ListSheetName);
+        if (sheet == null)
+        {
+            sheet = workbook.CreateSheet(ListSheetName);
+            workbook.SetSheetHidden(workbook.GetSheetIndex(sheet), SheetVisibility.Hidden);
+        }
+
+        // the sheet grows to the right, one column per list, so lists written earlier keep their range
+        var column = 0;
+        var header = sheet.GetRow(0);
+        if (header != null) column = header.LastCellNum < 0 ? 0 : header.LastCellNum;
+
+        for (var i = 0; i < values.Length; i++)
+        {
+            var row = sheet.GetRow(i) ?? sheet.CreateRow(i);
+            row.CreateCell(column).SetCellValue(values[i]);
+        }
+
+        var letter = CellReference.ConvertNumToColString(column);
+        return $"{ListSheetName}!${letter}$1:${letter}${values.Length}";
+    }
+}

--- a/Chsword.Excel2Object/Internal/DropdownValidation.cs
+++ b/Chsword.Excel2Object/Internal/DropdownValidation.cs
@@ -58,12 +58,7 @@ internal static class DropdownValidation
     /// <summary>Puts the values in their own column on the hidden sheet and returns the range.</summary>
     private static string WriteToListSheet(IWorkbook workbook, string[] values)
     {
-        var sheet = workbook.GetSheet(ListSheetName);
-        if (sheet == null)
-        {
-            sheet = workbook.CreateSheet(ListSheetName);
-            workbook.SetSheetHidden(workbook.GetSheetIndex(sheet), SheetVisibility.Hidden);
-        }
+        var sheet = ListSheet(workbook);
 
         // the sheet grows to the right, one column per list, so lists written earlier keep their range
         var column = 0;
@@ -77,6 +72,32 @@ internal static class DropdownValidation
         }
 
         var letter = CellReference.ConvertNumToColString(column);
-        return $"{ListSheetName}!${letter}$1:${letter}${values.Length}";
+        // the name needs no quoting, which matters: xlsx keeps the formula as written while xls reparses it
+        return $"{sheet.SheetName}!${letter}$1:${letter}${values.Length}";
+    }
+
+    /// <summary>
+    ///     The sheet the long lists are written to: the one an earlier export of this workbook left behind,
+    ///     or a new hidden one. A visible sheet of that name belongs to whoever made the workbook, so a name
+    ///     that is still free is taken instead of writing into it.
+    /// </summary>
+    private static ISheet ListSheet(IWorkbook workbook)
+    {
+        var name = ListSheetName;
+        for (var suffix = 2;; suffix++)
+        {
+            var existing = workbook.GetSheet(name);
+            if (existing == null)
+            {
+                var sheet = workbook.CreateSheet(name);
+                workbook.SetSheetHidden(workbook.GetSheetIndex(sheet), SheetVisibility.Hidden);
+                return sheet;
+            }
+
+            if (workbook.GetSheetVisibility(workbook.GetSheetIndex(existing)) != SheetVisibility.Visible)
+                return existing;
+
+            name = ListSheetName + suffix;
+        }
     }
 }

--- a/Chsword.Excel2Object/Internal/DropdownValidation.cs
+++ b/Chsword.Excel2Object/Internal/DropdownValidation.cs
@@ -9,14 +9,20 @@ namespace Chsword.Excel2Object.Internal;
 /// <remarks>
 ///     A short list is written into the validation itself. Excel only accepts 255 characters there
 ///     (and splits the list on commas), so a longer list, or one whose values carry a comma or a quote,
-///     is written into a hidden sheet the validation then points at.
+///     is written into a hidden sheet that a defined name points at, and the validation reads the name.
 /// </remarks>
 internal static class DropdownValidation
 {
     /// <summary>The hidden sheet the long lists live on.</summary>
     private const string ListSheetName = "_excel2object_lists";
 
-    /// <summary>What Excel accepts inside a list validation, commas and quotes included.</summary>
+    /// <summary>The defined names pointing at those lists, numbered from one.</summary>
+    private const string ListNamePrefix = "_excel2object_list";
+
+    /// <summary>
+    ///     What Excel accepts inside a list validation. The list is stored as one quoted literal, so the
+    ///     two quotes around it count against the limit along with the commas between the values.
+    /// </summary>
     private const int InlineLimit = 255;
 
     public static void Apply(ISheet sheet, ExcelColumn[] columns, int lastDataRowIndex)
@@ -29,6 +35,7 @@ internal static class DropdownValidation
         {
             var values = columns[i].Dropdown;
             if (values == null || values.Length == 0) continue;
+            Validate(values, columns[i].Title);
 
             var constraint = FitsInline(values)
                 ? helper.CreateExplicitListConstraint(values)
@@ -43,9 +50,18 @@ internal static class DropdownValidation
         }
     }
 
+    private static void Validate(string[] values, string? title)
+    {
+        for (var i = 0; i < values.Length; i++)
+            if (values[i] == null)
+                throw new Excel2ObjectException(
+                    $"Dropdown column [{title}] has no value at index {i}. Excel has no empty entry in a " +
+                    "list; leave the cell blank instead of offering one.");
+    }
+
     private static bool FitsInline(string[] values)
     {
-        var length = values.Length - 1; // the commas between them
+        var length = values.Length - 1 + 2; // the commas between the values, and the quotes around them all
         foreach (var value in values)
         {
             if (value.IndexOf(',') >= 0 || value.IndexOf('"') >= 0) return false;
@@ -55,7 +71,11 @@ internal static class DropdownValidation
         return length <= InlineLimit;
     }
 
-    /// <summary>Puts the values in their own column on the hidden sheet and returns the range.</summary>
+    /// <summary>
+    ///     Puts the values in their own column on the hidden sheet and returns the defined name covering
+    ///     them. A validation reads the name rather than the range itself, because the .xls format has no
+    ///     way to point a validation at another sheet directly.
+    /// </summary>
     private static string WriteToListSheet(IWorkbook workbook, string[] values)
     {
         var sheet = ListSheet(workbook);
@@ -72,8 +92,23 @@ internal static class DropdownValidation
         }
 
         var letter = CellReference.ConvertNumToColString(column);
-        // the name needs no quoting, which matters: xlsx keeps the formula as written while xls reparses it
-        return $"{sheet.SheetName}!${letter}$1:${letter}${values.Length}";
+        // the sheet name needs no quoting, which matters: xlsx keeps the formula as written while xls
+        // reparses it
+        var range = $"{sheet.SheetName}!${letter}$1:${letter}${values.Length}";
+
+        var name = workbook.CreateName();
+        name.NameName = FreeName(workbook);
+        name.RefersToFormula = range;
+        return name.NameName;
+    }
+
+    private static string FreeName(IWorkbook workbook)
+    {
+        for (var i = 1;; i++)
+        {
+            var name = ListNamePrefix + i;
+            if (workbook.GetName(name) == null) return name;
+        }
     }
 
     /// <summary>

--- a/Chsword.Excel2Object/Internal/TypeConvert.cs
+++ b/Chsword.Excel2Object/Internal/TypeConvert.cs
@@ -60,6 +60,7 @@ internal static class TypeConvert
             {
                 column.CellStyle = excelColumnAttr;
                 column.HeaderStyle = excelColumnAttr;
+                column.Dropdown = excelColumnAttr.Dropdown;
             }
 
             columns.Add(column);
@@ -113,6 +114,10 @@ internal static class TypeConvert
     private static List<ExcelColumn> AttachColumns(List<ExcelColumn> columns, ExcelExporterOptions options)
     {
         columns = columns.OrderBy(c => c.Order).ToList();
+        foreach (var column in columns)
+            if (column.Title != null && options.Dropdowns.TryGetValue(column.Title, out var values))
+                column.Dropdown = values;
+
         foreach (var formulaColumn in options.FormulaColumns)
         {
             var excelColumn = columns.FirstOrDefault(c => c.Title == formulaColumn.Title);

--- a/Chsword.Excel2Object/Internal/TypeConvert.cs
+++ b/Chsword.Excel2Object/Internal/TypeConvert.cs
@@ -114,10 +114,6 @@ internal static class TypeConvert
     private static List<ExcelColumn> AttachColumns(List<ExcelColumn> columns, ExcelExporterOptions options)
     {
         columns = columns.OrderBy(c => c.Order).ToList();
-        foreach (var column in columns)
-            if (column.Title != null && options.Dropdowns.TryGetValue(column.Title, out var values))
-                column.Dropdown = values;
-
         foreach (var formulaColumn in options.FormulaColumns)
         {
             var excelColumn = columns.FirstOrDefault(c => c.Title == formulaColumn.Title);
@@ -154,6 +150,11 @@ internal static class TypeConvert
                 excelColumn.Formula = formulaColumn.ModelFormula ?? formulaColumn.Formula;
             }
         }
+
+        // after the formula columns are in, so a column a formula added can carry a dropdown too
+        foreach (var column in columns)
+            if (column.Title != null && options.Dropdowns.TryGetValue(column.Title, out var values))
+                column.Dropdown = values;
 
         for (var i = 0; i < columns.Count; i++) columns[i].Order = i * 10;
 

--- a/Chsword.Excel2Object/Models/ExcelColumn.cs
+++ b/Chsword.Excel2Object/Models/ExcelColumn.cs
@@ -20,4 +20,7 @@ internal class ExcelColumn
 
     public string? Title { get; set; }
     public Type? Type { get; set; }
+
+    /// <summary>The values the column's cells are limited to, shown as a dropdown.</summary>
+    public string[]? Dropdown { get; set; }
 }

--- a/Chsword.Excel2Object/Options/ExcelExporterOptions.cs
+++ b/Chsword.Excel2Object/Options/ExcelExporterOptions.cs
@@ -47,4 +47,15 @@ public class ExcelExporterOptions
     ///     Excel, but comes out character for character as <c>[ExcelColumn(Format = ...)]</c> renders it.
     /// </summary>
     public bool DateTimeAsText { get; set; }
+
+    /// <summary>
+    ///     Freeze the header row, so it stays in view while the sheet is scrolled (default: false).
+    /// </summary>
+    public bool FreezeHeader { get; set; }
+
+    /// <summary>
+    ///     Put Excel's filter dropdowns on the header row, over the data written in this export
+    ///     (default: false).
+    /// </summary>
+    public bool AutoFilter { get; set; }
 }

--- a/Chsword.Excel2Object/Options/ExcelExporterOptions.cs
+++ b/Chsword.Excel2Object/Options/ExcelExporterOptions.cs
@@ -54,6 +54,13 @@ public class ExcelExporterOptions
     public bool FreezeHeader { get; set; }
 
     /// <summary>
+    ///     The values a column's cells are limited to, keyed by column title - the runtime counterpart of
+    ///     <see cref="ExcelColumnAttribute.Dropdown" />, which it takes precedence over. Excel shows them
+    ///     as a dropdown and rejects anything else.
+    /// </summary>
+    public IDictionary<string, string[]> Dropdowns { get; set; } = new Dictionary<string, string[]>();
+
+    /// <summary>
     ///     Put Excel's filter dropdowns on the header row, over the data written in this export
     ///     (default: false).
     /// </summary>

--- a/README.md
+++ b/README.md
@@ -280,6 +280,19 @@ var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
 });
 ```
 
+### 冻结首行与自动筛选
+
+``` csharp
+var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
+{
+    options.ExcelType = ExcelType.Xlsx;
+    options.FreezeHeader = true;           // 滚动时表头始终可见
+    options.AutoFilter = true;             // 表头带上筛选下拉
+});
+```
+
+两个选项默认关闭，`.xls` 与 `.xlsx` 都支持。筛选范围覆盖表头及本次写入的数据行；`AppendObjectToExcelBytes` 追加的 sheet 各自独立，不影响已有 sheet。
+
 ### 在 ASP.NET MVC 中使用
 
 在 ASP.NET MVC 模型中，`DisplayAttribute` 可以像 `ExcelTitleAttribute` 一样被支持。

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ excel2obj generate-model orders.xlsx --class Order           # 由表头生成�
 
 * **2026.09.12** - v2.5.0
 - [x] ✨ **新增:** `ExcelExporterOptions.FreezeHeader` 冻结首行，滚动时表头常驻；`ExcelExporterOptions.AutoFilter` 给表头挂上筛选下拉，范围覆盖本次写入的数据行。两项默认关闭，`.xls` / `.xlsx` 都支持
+- [x] ✨ **新增:** `AppendObjectToExcelBytes` 增加接受 options 的重载，追加 sheet 时也能设置冻结、筛选与下拉
 - [x] ✨ **新增:** 数据验证（下拉列表）：固定取值写在 `[ExcelColumn("状态", Dropdown = new[] {"启用", "停用"})]`，运行时取值走 `options.Dropdowns["列标题"] = values`（优先于特性）。Excel 会拒绝列表之外的输入；列表总长超过 255 字符或取值含逗号/引号时自动改用隐藏 sheet 承载（此前这种列表在 `.xls` 上会直接抛异常），空导出也会在首行挂上下拉以便做填写模板
 
 * **2026.09.11** - v2.4.0
@@ -320,7 +321,7 @@ var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
 });
 ```
 
-Excel 会把取值显示为下拉，并拒绝其他输入。列表总长超过 255 字符、或取值里含逗号/引号时（Excel 行内列表放不下），自动改写到一张隐藏 sheet 上再由下拉引用，用法不变；`.xls` 与 `.xlsx` 都支持。导出空列表时下拉仍会挂在第一行，方便做填写模板。
+Excel 会把取值显示为下拉，并拒绝其他输入。追加导出用 `ExcelHelper.AppendObjectToExcelBytes(bytes, models, options => ...)` 同样可以设置这些选项。列表总长超过 255 字符、或取值里含逗号/引号时（Excel 行内列表放不下），自动改写到一张隐藏 sheet 上再由下拉引用，用法不变；`.xls` 与 `.xlsx` 都支持。导出空列表时下拉仍会挂在第一行，方便做填写模板。
 
 ### 在 ASP.NET MVC 中使用
 

--- a/README.md
+++ b/README.md
@@ -293,6 +293,29 @@ var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
 
 两个选项默认关闭，`.xls` 与 `.xlsx` 都支持。筛选范围覆盖表头及本次写入的数据行；`AppendObjectToExcelBytes` 追加的 sheet 各自独立，不影响已有 sheet。
 
+### 数据验证（下拉列表）
+
+``` csharp
+public class OrderModel
+{
+    [ExcelTitle("订单号")] public string No { get; set; }
+
+    // 固定取值写在特性上
+    [ExcelColumn("状态", Dropdown = new[] {"启用", "停用", "待审"})]
+    public string Status { get; set; }
+
+    [ExcelTitle("城市")] public string City { get; set; }
+}
+
+var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
+{
+    // 运行时才知道的取值走 options，优先于特性
+    options.Dropdowns["城市"] = cities.Select(c => c.Name).ToArray();
+});
+```
+
+Excel 会把取值显示为下拉，并拒绝其他输入。列表总长超过 255 字符、或取值里含逗号/引号时（Excel 行内列表放不下），自动改写到一张隐藏 sheet 上再由下拉引用，用法不变；`.xls` 与 `.xlsx` 都支持。导出空列表时下拉仍会挂在第一行，方便做填写模板。
+
 ### 在 ASP.NET MVC 中使用
 
 在 ASP.NET MVC 模型中，`DisplayAttribute` 可以像 `ExcelTitleAttribute` 一样被支持。

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
 });
 ```
 
-Excel 会把取值显示为下拉，并拒绝其他输入。追加导出用 `ExcelHelper.AppendObjectToExcelBytes(bytes, models, options => ...)` 同样可以设置这些选项。列表总长超过 255 字符、或取值里含逗号/引号时（Excel 行内列表放不下），自动改写到一张隐藏 sheet 上再由下拉引用，用法不变；`.xls` 与 `.xlsx` 都支持。导出空列表时下拉仍会挂在第一行，方便做填写模板。
+Excel 会把取值显示为下拉，并拒绝其他输入。追加导出用 `ExcelHelper.AppendObjectToExcelBytes(bytes, models, options => ...)` 同样可以设置这些选项。列表总长超过 255 字符、或取值里含逗号/引号时（Excel 行内列表放不下），自动改写到一张隐藏 sheet 上、由一个定义名称指向该区域，下拉再引用这个名称（`.xls` 无法让数据验证直接跨 sheet 引用），用法不变；`.xls` 与 `.xlsx` 都支持。导出空列表时下拉仍会挂在第一行，方便做填写模板。
 
 ### 在 ASP.NET MVC 中使用
 

--- a/README.md
+++ b/README.md
@@ -55,11 +55,17 @@ excel2obj generate-model orders.xlsx --class Order           # 由表头生成�
 
 - [x] CLI 工具 ✅ **v2.2.1 新增** - `dotnet tool install -g Chsword.Excel2Object.Cli`，查看 [Chsword.Excel2Object.Cli/README.md](Chsword.Excel2Object.Cli/README.md)
 - [x] 支持自动列宽 ✅ **v2.0.4 新增**
+- [x] 冻结首行与自动筛选 ✅ **v2.5.0 新增**
+- [x] 数据验证（下拉列表）✅ **v2.5.0 新增**
 - [x] 支持 Excel 日期/日期时间/时间格式 ✅ **v2.0.4 新增**，导出为真正的日期单元格 ✅ **v2.4.0 新增** - 查看 [DateTimeFormats.md](DateTimeFormats.md)
 - [x] 公式列引用同一工作簿的其他 sheet ✅ **v2.1.0 新增** - 查看 [ExcelFunctions.md](ExcelFunctions.md)
 - [x] 公式内置函数库 ✅ **v2.3.0 新增** - 334 个 Excel 函数，10 个类别 - 查看 [ExcelFunctions.md](ExcelFunctions.md)
 
 ### 发布说明
+
+* **2026.09.12** - v2.5.0
+- [x] ✨ **新增:** `ExcelExporterOptions.FreezeHeader` 冻结首行，滚动时表头常驻；`ExcelExporterOptions.AutoFilter` 给表头挂上筛选下拉，范围覆盖本次写入的数据行。两项默认关闭，`.xls` / `.xlsx` 都支持
+- [x] ✨ **新增:** 数据验证（下拉列表）：固定取值写在 `[ExcelColumn("状态", Dropdown = new[] {"启用", "停用"})]`，运行时取值走 `options.Dropdowns["列标题"] = values`（优先于特性）。Excel 会拒绝列表之外的输入；列表总长超过 255 字符或取值含逗号/引号时自动改用隐藏 sheet 承载（此前这种列表在 `.xls` 上会直接抛异常），空导出也会在首行挂上下拉以便做填写模板
 
 * **2026.09.11** - v2.4.0
 - [x] ✨ **新增:** 导出时 `DateTime` / `DateTime?` 列写成真正的日期单元格（序列号 + 日期格式），Excel 可以排序、筛选、参与计算，`null` 写成空单元格；`Dictionary<string, object>` 与 `DataTable` 导出中的 `DateTime` 值同样处理 - 查看 [DateTimeFormats.md](DateTimeFormats.md)

--- a/README_EN.md
+++ b/README_EN.md
@@ -318,7 +318,7 @@ var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
 });
 ```
 
-Excel shows the values as a dropdown and rejects anything else. `ExcelHelper.AppendObjectToExcelBytes(bytes, models, options => ...)` takes the same options when appending a sheet. A list Excel cannot hold inline - over 255 characters in total, or a value carrying a comma or a quote - is written to a hidden sheet the dropdown reads from, which changes nothing about how it is used; both `.xls` and `.xlsx` support it. An export with no rows still gets the dropdown on its first row, so it works as a template to fill in.
+Excel shows the values as a dropdown and rejects anything else. `ExcelHelper.AppendObjectToExcelBytes(bytes, models, options => ...)` takes the same options when appending a sheet. A list Excel cannot hold inline - over 255 characters in total, or a value carrying a comma or a quote - is written to a hidden sheet that a defined name points at, which the dropdown then reads (a `.xls` validation cannot reference another sheet directly); nothing about how it is used changes, and both `.xls` and `.xlsx` support it. An export with no rows still gets the dropdown on its first row, so it works as a template to fill in.
 
 ### Use with ASP.NET MVC
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -277,6 +277,19 @@ var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
 });
 ```
 
+### Frozen Header and Filter Dropdowns
+
+``` csharp
+var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
+{
+    options.ExcelType = ExcelType.Xlsx;
+    options.FreezeHeader = true;           // the header stays in view while scrolling
+    options.AutoFilter = true;             // the header carries Excel's filter dropdowns
+});
+```
+
+Both are off by default and work in `.xls` as well as `.xlsx`. The filter covers the header and the rows written in this export; a sheet appended with `AppendObjectToExcelBytes` gets its own, leaving the sheets already in the workbook alone.
+
 ### Use with ASP.NET MVC
 
 In ASP.NET MVC models, the `DisplayAttribute` can be supported like `ExcelTitleAttribute`.

--- a/README_EN.md
+++ b/README_EN.md
@@ -53,11 +53,17 @@ See [Chsword.Excel2Object.Cli/README.md](Chsword.Excel2Object.Cli/README.md).
 
 - [x] CLI tool ✅ **New in v2.2.1** - `dotnet tool install -g Chsword.Excel2Object.Cli`, see [Chsword.Excel2Object.Cli/README.md](Chsword.Excel2Object.Cli/README.md)
 - [x] Support auto width column ✅ **New in v2.0.4**
+- [x] Frozen header row and filter dropdowns ✅ **New in v2.5.0**
+- [x] Data validation (dropdown lists) ✅ **New in v2.5.0**
 - [x] Support date/datetime/time formats in Excel ✅ **New in v2.0.4**, exported as real date cells ✅ **New in v2.4.0** - See [DateTimeFormats.md](DateTimeFormats.md)
 - [x] Formula columns referencing other sheets of the same workbook ✅ **New in v2.1.0** - See [ExcelFunctions.md](ExcelFunctions.md)
 - [x] Built-in formula function library ✅ **New in v2.3.0** - 334 Excel functions in 10 categories - See [ExcelFunctions.md](ExcelFunctions.md)
 
 ### Release Notes
+
+* **2026.09.12** - v2.5.0
+- [x] ✨ **NEW:** `ExcelExporterOptions.FreezeHeader` freezes the header row so it stays in view while scrolling, and `ExcelExporterOptions.AutoFilter` puts Excel's filter dropdowns on it over the rows this export wrote. Both are off by default and work in `.xls` as well as `.xlsx`
+- [x] ✨ **NEW:** Data validation (dropdown lists): a fixed list goes on the attribute, `[ExcelColumn("Status", Dropdown = new[] {"Open", "Closed"})]`, and values only known at runtime go through `options.Dropdowns["Column title"] = values`, which wins over the attribute. Excel rejects anything outside the list; a list over 255 characters, or one whose values carry a comma or a quote, is written to a hidden sheet the dropdown reads from (such a list used to throw outright on `.xls`), and an export with no rows still gets the dropdown on its first row so it works as a template
 
 * **2026.09.11** - v2.4.0
 - [x] ✨ **NEW:** `DateTime` / `DateTime?` columns are exported as real date cells (a serial number with a date format), so Excel can sort, filter and calculate with them; `null` becomes a blank cell. `DateTime` values in `Dictionary<string, object>` and `DataTable` exports get the same treatment - See [DateTimeFormats.md](DateTimeFormats.md)

--- a/README_EN.md
+++ b/README_EN.md
@@ -63,6 +63,7 @@ See [Chsword.Excel2Object.Cli/README.md](Chsword.Excel2Object.Cli/README.md).
 
 * **2026.09.12** - v2.5.0
 - [x] ✨ **NEW:** `ExcelExporterOptions.FreezeHeader` freezes the header row so it stays in view while scrolling, and `ExcelExporterOptions.AutoFilter` puts Excel's filter dropdowns on it over the rows this export wrote. Both are off by default and work in `.xls` as well as `.xlsx`
+- [x] ✨ **NEW:** `AppendObjectToExcelBytes` gained an options overload, so an appended sheet can be frozen, filtered and given dropdowns too
 - [x] ✨ **NEW:** Data validation (dropdown lists): a fixed list goes on the attribute, `[ExcelColumn("Status", Dropdown = new[] {"Open", "Closed"})]`, and values only known at runtime go through `options.Dropdowns["Column title"] = values`, which wins over the attribute. Excel rejects anything outside the list; a list over 255 characters, or one whose values carry a comma or a quote, is written to a hidden sheet the dropdown reads from (such a list used to throw outright on `.xls`), and an export with no rows still gets the dropdown on its first row so it works as a template
 
 * **2026.09.11** - v2.4.0
@@ -317,7 +318,7 @@ var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
 });
 ```
 
-Excel shows the values as a dropdown and rejects anything else. A list Excel cannot hold inline - over 255 characters in total, or a value carrying a comma or a quote - is written to a hidden sheet the dropdown reads from, which changes nothing about how it is used; both `.xls` and `.xlsx` support it. An export with no rows still gets the dropdown on its first row, so it works as a template to fill in.
+Excel shows the values as a dropdown and rejects anything else. `ExcelHelper.AppendObjectToExcelBytes(bytes, models, options => ...)` takes the same options when appending a sheet. A list Excel cannot hold inline - over 255 characters in total, or a value carrying a comma or a quote - is written to a hidden sheet the dropdown reads from, which changes nothing about how it is used; both `.xls` and `.xlsx` support it. An export with no rows still gets the dropdown on its first row, so it works as a template to fill in.
 
 ### Use with ASP.NET MVC
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -290,6 +290,29 @@ var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
 
 Both are off by default and work in `.xls` as well as `.xlsx`. The filter covers the header and the rows written in this export; a sheet appended with `AppendObjectToExcelBytes` gets its own, leaving the sheets already in the workbook alone.
 
+### Data Validation (Dropdown Lists)
+
+``` csharp
+public class OrderModel
+{
+    [ExcelTitle("No")] public string No { get; set; }
+
+    // a fixed list belongs on the attribute
+    [ExcelColumn("Status", Dropdown = new[] {"Open", "Closed", "Pending"})]
+    public string Status { get; set; }
+
+    [ExcelTitle("City")] public string City { get; set; }
+}
+
+var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
+{
+    // values only known at runtime go through the options and win over the attribute
+    options.Dropdowns["City"] = cities.Select(c => c.Name).ToArray();
+});
+```
+
+Excel shows the values as a dropdown and rejects anything else. A list Excel cannot hold inline - over 255 characters in total, or a value carrying a comma or a quote - is written to a hidden sheet the dropdown reads from, which changes nothing about how it is used; both `.xls` and `.xlsx` support it. An export with no rows still gets the dropdown on its first row, so it works as a template to fill in.
+
 ### Use with ASP.NET MVC
 
 In ASP.NET MVC models, the `DisplayAttribute` can be supported like `ExcelTitleAttribute`.


### PR DESCRIPTION
## 背景

导出上千行时表头一滚就看不见，筛选还得手动选区域；而"某列只能填这几个值"一直只能靠导出后手工加数据验证。

## 变更

**冻结首行 / 自动筛选**

```csharp
options.FreezeHeader = true;   // 滚动时表头常驻
options.AutoFilter = true;     // 表头带筛选下拉
```

两项默认关闭，`.xls` / `.xlsx` 都支持；筛选范围覆盖表头与本次写入的数据行；`AppendObjectToExcelBytes` 追加的 sheet 各自独立，不动已有 sheet。

**数据验证（下拉列表）**

```csharp
[ExcelColumn("状态", Dropdown = new[] {"启用", "停用", "待审"})]
public string Status { get; set; }

// 运行时取值，优先于特性
options.Dropdowns["城市"] = cities.Select(c => c.Name).ToArray();
```

Excel 拒绝列表之外的输入。列表总长超过 255 字符、或取值含逗号/引号时（Excel 行内列表放不下，`.xls` 更是直接抛 `String literals in formulas can't be bigger than 255 Chars`），自动写到一张隐藏 sheet 上再由下拉引用，每个列表占一列。空导出也会在首行挂上下拉，便于做填写模板。

## 测试

新增 `HeaderViewTest`（5 个）与 `DropdownTest`（8 个），覆盖两种文件格式、空数据、追加 sheet、长列表与含逗号取值的隐藏 sheet 承载、以及往返导入。全套 279 个测试通过，所有 TFM 构建 0 警告。

版本 2.4.0 → 2.5.0，README / README_EN 补了示例与发布说明。

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)