### PR TITLE
条件格式 (v2.6.0)

### DIFF
--- a/Chsword.Excel2Object.Tests/ConditionalFormatTest.cs
+++ b/Chsword.Excel2Object.Tests/ConditionalFormatTest.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Chsword.Excel2Object.Options;
+using Chsword.Excel2Object.Styles;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NPOI.SS.UserModel;
+using NPOI.SS.Util;
+
+namespace Chsword.Excel2Object.Tests;
+
+/// <summary>
+///     A rule restyles the cells whose value meets a condition, and Excel keeps re-evaluating it as the
+///     sheet is edited.
+/// </summary>
+[TestClass]
+public class ConditionalFormatTest : BaseExcelTest
+{
+    public class Model
+    {
+        [ExcelTitle("城市")] public string City { get; set; } = "北京";
+        [ExcelTitle("金额")] public decimal Amount { get; set; } = 1000;
+        [ExcelTitle("日期")] public DateTime When { get; set; } = new(2026, 9, 12);
+    }
+
+    private static readonly List<Model> Rows = new() {new(), new() {Amount = 20000}};
+
+    private static ISheet Export(ExcelType excelType, Action<ExcelExporterOptions> configure,
+        List<Model>? rows = null)
+    {
+        var bytes = new ExcelExporter().ObjectToExcelBytes(rows ?? Rows, options =>
+        {
+            options.ExcelType = excelType;
+            configure(options);
+        });
+        Assert.IsNotNull(bytes);
+        return WorkbookFactory.Create(new MemoryStream(bytes)).GetSheetAt(0);
+    }
+
+    private static IConditionalFormattingRule SingleRule(ISheet sheet, out CellRangeAddress[] ranges)
+    {
+        var formatting = sheet.SheetConditionalFormatting;
+        Assert.AreEqual(1, formatting.NumConditionalFormattings);
+        var applied = formatting.GetConditionalFormattingAt(0);
+        ranges = applied.GetFormattingRanges();
+        return applied.GetRule(0);
+    }
+
+    [TestMethod]
+    public void AComparisonColoursItsOwnColumnInBothFileFormats()
+    {
+        foreach (var excelType in new[] {ExcelType.Xlsx, ExcelType.Xls})
+        {
+            var sheet = Export(excelType, options => options.ConditionalFormats.Add(new ConditionalFormat("金额")
+            {
+                Operator = ConditionalOperator.GreaterThan,
+                Value = 10000,
+                FontColor = ExcelStyleColor.Red,
+                Bold = true,
+                BackgroundColor = ExcelStyleColor.Yellow
+            }));
+
+            var rule = SingleRule(sheet, out var ranges);
+            Assert.AreEqual(ConditionType.CellValueIs, rule.ConditionType, excelType.ToString());
+            Assert.AreEqual(ComparisonOperator.GreaterThan, rule.ComparisonOperation, excelType.ToString());
+            Assert.AreEqual("10000", rule.Formula1, excelType.ToString());
+            Assert.AreEqual((short) ExcelStyleColor.Red, rule.FontFormatting.FontColorIndex, excelType.ToString());
+            Assert.IsTrue(rule.FontFormatting.IsBold, excelType.ToString());
+            Assert.AreEqual((short) ExcelStyleColor.Yellow, rule.PatternFormatting.FillBackgroundColor,
+                excelType.ToString());
+            // the header keeps its own look; the rule belongs to the data rows of that column
+            Assert.AreEqual("B2:B3", ranges[0].FormatAsString(), excelType.ToString());
+        }
+    }
+
+    /// <summary>A value is written as Excel's literal for its type, so a string is quoted.</summary>
+    [DataTestMethod]
+    [DataRow("急件", "\"急件\"")]
+    [DataRow(1500.5, "1500.5")]
+    public void TheValueBecomesAnExcelLiteral(object value, string literal)
+    {
+        var sheet = Export(ExcelType.Xlsx, options => options.ConditionalFormats.Add(new ConditionalFormat("城市")
+        {
+            Operator = ConditionalOperator.Equal,
+            Value = value,
+            Bold = true
+        }));
+
+        Assert.AreEqual(literal, SingleRule(sheet, out _).Formula1);
+    }
+
+    [TestMethod]
+    public void ADateIsComparedAsADate()
+    {
+        var sheet = Export(ExcelType.Xlsx, options => options.ConditionalFormats.Add(new ConditionalFormat("日期")
+        {
+            Operator = ConditionalOperator.LessThan,
+            Value = new DateTime(2026, 1, 31),
+            FontColor = ExcelStyleColor.Grey50Percent
+        }));
+
+        Assert.AreEqual("DATE(2026,1,31)", SingleRule(sheet, out _).Formula1);
+    }
+
+    [TestMethod]
+    public void BetweenTakesBothEnds()
+    {
+        var sheet = Export(ExcelType.Xlsx, options => options.ConditionalFormats.Add(new ConditionalFormat("金额")
+        {
+            Operator = ConditionalOperator.Between,
+            Value = 1000,
+            Value2 = 5000,
+            Italic = true
+        }));
+
+        var rule = SingleRule(sheet, out _);
+        Assert.AreEqual(ComparisonOperator.Between, rule.ComparisonOperation);
+        Assert.AreEqual("1000", rule.Formula1);
+        Assert.AreEqual("5000", rule.Formula2);
+        Assert.IsTrue(rule.FontFormatting.IsItalic);
+    }
+
+    /// <summary>A rule of your own is written as it is, against the first data row.</summary>
+    [TestMethod]
+    public void AFormulaRuleIsWrittenAsGiven()
+    {
+        var sheet = Export(ExcelType.Xlsx, options => options.ConditionalFormats.Add(new ConditionalFormat("金额")
+        {
+            Formula = "$B2>$B3",
+            BackgroundColor = ExcelStyleColor.LightGreen
+        }));
+
+        var rule = SingleRule(sheet, out _);
+        Assert.AreEqual(ConditionType.Formula, rule.ConditionType);
+        Assert.AreEqual("$B2>$B3", rule.Formula1);
+    }
+
+    /// <summary>
+    ///     The whole row can take the colour instead. Excel compares the cell a rule is written on, so the
+    ///     comparison becomes an expression anchored on the column it watches.
+    /// </summary>
+    [TestMethod]
+    public void WholeRowColoursEveryColumn()
+    {
+        foreach (var excelType in new[] {ExcelType.Xlsx, ExcelType.Xls})
+        {
+            var sheet = Export(excelType, options => options.ConditionalFormats.Add(new ConditionalFormat("金额")
+            {
+                Operator = ConditionalOperator.GreaterThan,
+                Value = 10000,
+                WholeRow = true,
+                BackgroundColor = ExcelStyleColor.Yellow
+            }));
+
+            var rule = SingleRule(sheet, out var ranges);
+            Assert.AreEqual(ConditionType.Formula, rule.ConditionType, excelType.ToString());
+            Assert.AreEqual("$B2>10000", rule.Formula1, excelType.ToString());
+            Assert.AreEqual("A2:C3", ranges[0].FormatAsString(), excelType.ToString());
+        }
+    }
+
+    [TestMethod]
+    public void SeveralRulesCanWatchTheSameColumn()
+    {
+        var sheet = Export(ExcelType.Xlsx, options =>
+        {
+            options.ConditionalFormats.Add(new ConditionalFormat("金额")
+                {Operator = ConditionalOperator.GreaterThan, Value = 10000, FontColor = ExcelStyleColor.Red});
+            options.ConditionalFormats.Add(new ConditionalFormat("金额")
+                {Operator = ConditionalOperator.LessThan, Value = 100, FontColor = ExcelStyleColor.Blue});
+        });
+
+        Assert.AreEqual(2, sheet.SheetConditionalFormatting.NumConditionalFormattings);
+    }
+
+    /// <summary>An empty export is a template, and the rule has to outlive the rows it was written with.</summary>
+    [TestMethod]
+    public void AnEmptySheetStillGetsTheRule()
+    {
+        var sheet = Export(ExcelType.Xlsx, options => options.ConditionalFormats.Add(new ConditionalFormat("金额")
+            {Operator = ConditionalOperator.GreaterThan, Value = 1, Bold = true}), new List<Model>());
+
+        SingleRule(sheet, out var ranges);
+        Assert.AreEqual("B2", ranges[0].FormatAsString());
+    }
+
+    [TestMethod]
+    public void AnUnknownColumnSaysSo()
+    {
+        var e = Assert.ThrowsException<Excel2ObjectException>(() =>
+            Export(ExcelType.Xlsx, options => options.ConditionalFormats.Add(new ConditionalFormat("不存在")
+                {Operator = ConditionalOperator.GreaterThan, Value = 1})));
+
+        StringAssert.Contains(e.Message, "不存在");
+    }
+
+    [TestMethod]
+    public void AComparisonWithoutAValueSaysSo()
+    {
+        var e = Assert.ThrowsException<Excel2ObjectException>(() =>
+            Export(ExcelType.Xlsx, options => options.ConditionalFormats.Add(new ConditionalFormat("金额")
+                {Operator = ConditionalOperator.GreaterThan})));
+
+        StringAssert.Contains(e.Message, "Value");
+    }
+}

--- a/Chsword.Excel2Object.Tests/ConditionalFormatTest.cs
+++ b/Chsword.Excel2Object.Tests/ConditionalFormatTest.cs
@@ -202,5 +202,49 @@ public class ConditionalFormatTest : BaseExcelTest
                 {Operator = ConditionalOperator.GreaterThan})));
 
         StringAssert.Contains(e.Message, "Value");
+        // which of the rules is at fault, when there are several
+        StringAssert.Contains(e.Message, "金额");
+        StringAssert.Contains(e.Message, "GreaterThan");
+    }
+
+    /// <summary>Between without its other end would reach NPOI as half a rule.</summary>
+    [DataTestMethod]
+    [DataRow(ConditionalOperator.Between)]
+    [DataRow(ConditionalOperator.NotBetween)]
+    public void BetweenWithoutTheOtherEndSaysSo(ConditionalOperator op)
+    {
+        var e = Assert.ThrowsException<Excel2ObjectException>(() =>
+            Export(ExcelType.Xlsx, options => options.ConditionalFormats.Add(new ConditionalFormat("金额")
+                {Operator = op, Value = 1000})));
+
+        StringAssert.Contains(e.Message, "Value2");
+        StringAssert.Contains(e.Message, "金额");
+    }
+
+    [TestMethod]
+    public void ARuleWithNeitherOperatorNorFormulaSaysSo()
+    {
+        var e = Assert.ThrowsException<Excel2ObjectException>(() =>
+            Export(ExcelType.Xlsx, options => options.ConditionalFormats.Add(new ConditionalFormat("金额")
+                {Bold = true})));
+
+        StringAssert.Contains(e.Message, "Formula");
+        StringAssert.Contains(e.Message, "金额");
+    }
+
+    /// <summary>A whole-row Between becomes an expression over both ends.</summary>
+    [TestMethod]
+    public void WholeRowBetweenSpellsOutBothEnds()
+    {
+        var sheet = Export(ExcelType.Xlsx, options => options.ConditionalFormats.Add(new ConditionalFormat("金额")
+        {
+            Operator = ConditionalOperator.Between,
+            Value = 1000,
+            Value2 = 5000,
+            WholeRow = true,
+            BackgroundColor = ExcelStyleColor.Yellow
+        }));
+
+        Assert.AreEqual("AND($B2>=1000,$B2<=5000)", SingleRule(sheet, out _).Formula1);
     }
 }

--- a/Chsword.Excel2Object/Chsword.Excel2Object.csproj
+++ b/Chsword.Excel2Object/Chsword.Excel2Object.csproj
@@ -13,7 +13,7 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Product>Chsword.Excel2Object Library</Product>
 		<Authors>Zou Jian</Authors>
-		<Version>2.5.0</Version>
+		<Version>2.6.0</Version>
 		<Copyright>Copyright ? 2014-2025</Copyright>
 		<PackageProjectUrl>https://github.com/chsword/Excel2Object/</PackageProjectUrl>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/Chsword.Excel2Object/ExcelExporter.cs
+++ b/Chsword.Excel2Object/ExcelExporter.cs
@@ -159,6 +159,7 @@ public class ExcelExporter
 
                 ApplyHeaderView(sheet, options, columns.Length, rowNumber - 1);
                 DropdownValidation.Apply(sheet, columns, rowNumber - 1);
+                ConditionalFormatting.Apply(sheet, columns, rowNumber - 1, options.ConditionalFormats);
             }
 
         return ToBytes(workbook);

--- a/Chsword.Excel2Object/Internal/ConditionalFormatting.cs
+++ b/Chsword.Excel2Object/Internal/ConditionalFormatting.cs
@@ -24,6 +24,7 @@ internal static class ConditionalFormatting
         foreach (var format in formats)
         {
             var column = IndexOf(columns, format.Title);
+            Validate(format);
             var rule = CreateRule(sheetFormatting, format, column);
 
             var font = rule.CreateFontFormatting();
@@ -54,6 +55,36 @@ internal static class ConditionalFormatting
             $"Conditional format refers to column [{title}], which is not in the sheet.");
     }
 
+    /// <summary>
+    ///     Says what a rule is missing before NPOI is handed an incomplete one, naming the column and the
+    ///     operator so the rule at fault is the one you go and look at.
+    /// </summary>
+    private static void Validate(ConditionalFormat format)
+    {
+        if (format.Operator == ConditionalOperator.None)
+        {
+            if (string.IsNullOrEmpty(format.Formula))
+                throw new Excel2ObjectException(
+                    $"{Describe(format)} has neither an Operator to compare with nor a Formula of its own.");
+            return;
+        }
+
+        if (format.Value == null)
+            throw new Excel2ObjectException($"{Describe(format)} needs a Value to compare with.");
+
+        if (format.Value2 == null &&
+            format.Operator is ConditionalOperator.Between or ConditionalOperator.NotBetween)
+            throw new Excel2ObjectException(
+                $"{Describe(format)} needs a Value2 as well - {format.Operator} takes both ends of the range.");
+    }
+
+    private static string Describe(ConditionalFormat format)
+    {
+        return format.Operator == ConditionalOperator.None
+            ? $"The conditional format on column [{format.Title}]"
+            : $"The conditional format on column [{format.Title}] ({format.Operator})";
+    }
+
     private static IConditionalFormattingRule CreateRule(ISheetConditionalFormatting sheetFormatting,
         ConditionalFormat format, int column)
     {
@@ -64,6 +95,7 @@ internal static class ConditionalFormatting
 
         return sheetFormatting.CreateConditionalFormattingRule(Operator(format.Operator),
             Literal(format.Value), format.Value2 == null ? null : Literal(format.Value2));
+
     }
 
     /// <summary>The comparison written as an expression, for a rule that colours more than its own cell.</summary>
@@ -108,8 +140,7 @@ internal static class ConditionalFormatting
     {
         return value switch
         {
-            null => throw new Excel2ObjectException(
-                "A conditional format needs a Value to compare with, or a Formula of its own."),
+            null => throw new Excel2ObjectException("A conditional format has no value to compare with."),
             DateTime date => $"DATE({date.Year},{date.Month},{date.Day})",
             bool flag => flag ? "TRUE" : "FALSE",
             string text => "\"" + text.Replace("\"", "\"\"") + "\"",

--- a/Chsword.Excel2Object/Internal/ConditionalFormatting.cs
+++ b/Chsword.Excel2Object/Internal/ConditionalFormatting.cs
@@ -95,7 +95,6 @@ internal static class ConditionalFormatting
 
         return sheetFormatting.CreateConditionalFormattingRule(Operator(format.Operator),
             Literal(format.Value), format.Value2 == null ? null : Literal(format.Value2));
-
     }
 
     /// <summary>The comparison written as an expression, for a rule that colours more than its own cell.</summary>

--- a/Chsword.Excel2Object/Internal/ConditionalFormatting.cs
+++ b/Chsword.Excel2Object/Internal/ConditionalFormatting.cs
@@ -1,0 +1,120 @@
+using System.Globalization;
+using Chsword.Excel2Object.Options;
+using Chsword.Excel2Object.Styles;
+using NPOI.SS.UserModel;
+using NPOI.SS.Util;
+
+namespace Chsword.Excel2Object.Internal;
+
+/// <summary>
+///     Writes the conditional formatting rules an export declares: Excel re-evaluates them as the sheet
+///     is edited, so the colours keep following the data.
+/// </summary>
+internal static class ConditionalFormatting
+{
+    public static void Apply(ISheet sheet, ExcelColumn[] columns, int lastDataRowIndex,
+        IList<ConditionalFormat> formats)
+    {
+        if (formats.Count == 0) return;
+
+        // an export with no rows still gets its rules, so a template keeps them once it is filled in
+        var lastRow = Math.Max(lastDataRowIndex, ExcelConstants.DefaultDataStartRowIndex);
+        var sheetFormatting = sheet.SheetConditionalFormatting;
+
+        foreach (var format in formats)
+        {
+            var column = IndexOf(columns, format.Title);
+            var rule = CreateRule(sheetFormatting, format, column);
+
+            var font = rule.CreateFontFormatting();
+            if (format.FontColor > 0) font.FontColorIndex = (short) format.FontColor;
+            if (format.Bold || format.Italic) font.SetFontStyle(format.Italic, format.Bold);
+
+            if (format.BackgroundColor > 0)
+            {
+                var pattern = rule.CreatePatternFormatting();
+                pattern.FillBackgroundColor = (short) format.BackgroundColor;
+                pattern.FillPattern = FillPattern.SolidForeground;
+            }
+
+            var lastColumn = format.WholeRow ? columns.Length - 1 : column;
+            var range = new CellRangeAddress(ExcelConstants.DefaultDataStartRowIndex, lastRow,
+                format.WholeRow ? 0 : column, lastColumn);
+            sheetFormatting.AddConditionalFormatting(new[] {range}, rule);
+        }
+    }
+
+    private static int IndexOf(ExcelColumn[] columns, string? title)
+    {
+        for (var i = 0; i < columns.Length; i++)
+            if (columns[i].Title == title)
+                return i;
+
+        throw new Excel2ObjectException(
+            $"Conditional format refers to column [{title}], which is not in the sheet.");
+    }
+
+    private static IConditionalFormattingRule CreateRule(ISheetConditionalFormatting sheetFormatting,
+        ConditionalFormat format, int column)
+    {
+        // a rule over the whole row can only be an expression - Excel compares the cell it is written on
+        if (format.Operator == ConditionalOperator.None || format.WholeRow)
+            return sheetFormatting.CreateConditionalFormattingRule(
+                format.Formula ?? ComparisonFormula(format, column));
+
+        return sheetFormatting.CreateConditionalFormattingRule(Operator(format.Operator),
+            Literal(format.Value), format.Value2 == null ? null : Literal(format.Value2));
+    }
+
+    /// <summary>The comparison written as an expression, for a rule that colours more than its own cell.</summary>
+    private static string ComparisonFormula(ConditionalFormat format, int column)
+    {
+        // the column is anchored and the row is not, so Excel moves the rule down the rows
+        var cell = $"${CellReference.ConvertNumToColString(column)}{ExcelConstants.DefaultDataStartRowIndex + 1}";
+        var value = Literal(format.Value);
+
+        return format.Operator switch
+        {
+            ConditionalOperator.Between => $"AND({cell}>={value},{cell}<={Literal(format.Value2)})",
+            ConditionalOperator.NotBetween => $"OR({cell}<{value},{cell}>{Literal(format.Value2)})",
+            ConditionalOperator.Equal => $"{cell}={value}",
+            ConditionalOperator.NotEqual => $"{cell}<>{value}",
+            ConditionalOperator.GreaterThan => $"{cell}>{value}",
+            ConditionalOperator.LessThan => $"{cell}<{value}",
+            ConditionalOperator.GreaterThanOrEqual => $"{cell}>={value}",
+            ConditionalOperator.LessThanOrEqual => $"{cell}<={value}",
+            _ => throw new Excel2ObjectException($"Unsupported conditional operator {format.Operator}.")
+        };
+    }
+
+    private static ComparisonOperator Operator(ConditionalOperator value)
+    {
+        return value switch
+        {
+            ConditionalOperator.Between => ComparisonOperator.Between,
+            ConditionalOperator.NotBetween => ComparisonOperator.NotBetween,
+            ConditionalOperator.Equal => ComparisonOperator.Equal,
+            ConditionalOperator.NotEqual => ComparisonOperator.NotEqual,
+            ConditionalOperator.GreaterThan => ComparisonOperator.GreaterThan,
+            ConditionalOperator.LessThan => ComparisonOperator.LessThan,
+            ConditionalOperator.GreaterThanOrEqual => ComparisonOperator.GreaterThanOrEqual,
+            ConditionalOperator.LessThanOrEqual => ComparisonOperator.LessThanOrEqual,
+            _ => throw new Excel2ObjectException($"Unsupported conditional operator {value}.")
+        };
+    }
+
+    /// <summary>What the value looks like inside an Excel formula.</summary>
+    private static string Literal(object? value)
+    {
+        return value switch
+        {
+            null => throw new Excel2ObjectException(
+                "A conditional format needs a Value to compare with, or a Formula of its own."),
+            DateTime date => $"DATE({date.Year},{date.Month},{date.Day})",
+            bool flag => flag ? "TRUE" : "FALSE",
+            string text => "\"" + text.Replace("\"", "\"\"") + "\"",
+            IFormattable number when value is not char => number.ToString(null, CultureInfo.InvariantCulture),
+            _ => "\"" + value.ToString()!.Replace("\"", "\"\"") + "\""
+        };
+    }
+}

--- a/Chsword.Excel2Object/Options/ConditionalFormat.cs
+++ b/Chsword.Excel2Object/Options/ConditionalFormat.cs
@@ -1,0 +1,85 @@
+using Chsword.Excel2Object.Styles;
+
+namespace Chsword.Excel2Object.Options;
+
+/// <summary>How a cell's value is compared with <see cref="ConditionalFormat.Value" />.</summary>
+public enum ConditionalOperator
+{
+    /// <summary>No comparison: the rule is the <see cref="ConditionalFormat.Formula" />.</summary>
+    None = 0,
+    Between,
+    NotBetween,
+    Equal,
+    NotEqual,
+    GreaterThan,
+    LessThan,
+    GreaterThanOrEqual,
+    LessThanOrEqual
+}
+
+/// <summary>
+///     A rule that restyles the cells of one column when their value meets a condition - Excel's
+///     conditional formatting, so the colours follow the data as it is edited.
+/// </summary>
+/// <example>
+///     <code>
+/// options.ConditionalFormats.Add(new ConditionalFormat("金额")
+/// {
+///     Operator = ConditionalOperator.GreaterThan,
+///     Value = 10000,
+///     FontColor = ExcelStyleColor.Red,
+///     Bold = true
+/// });
+/// </code>
+/// </example>
+public class ConditionalFormat
+{
+    public ConditionalFormat()
+    {
+    }
+
+    public ConditionalFormat(string title)
+    {
+        Title = title;
+    }
+
+    /// <summary>The title of the column the rule watches.</summary>
+    public string? Title { get; set; }
+
+    /// <summary>
+    ///     How the cell is compared with <see cref="Value" />. Leave it unset to write the rule as a
+    ///     <see cref="Formula" /> instead.
+    /// </summary>
+    public ConditionalOperator Operator { get; set; }
+
+    /// <summary>
+    ///     What the cell is compared with. A number, a <see cref="DateTime" /> or a bool is written as
+    ///     Excel's literal for it, and a string is quoted, so <c>Value = "急件"</c> compares with that text.
+    /// </summary>
+    public object? Value { get; set; }
+
+    /// <summary>The other end of <see cref="ConditionalOperator.Between" /> and its negation.</summary>
+    public object? Value2 { get; set; }
+
+    /// <summary>
+    ///     An Excel condition of your own, true when the rule should apply, e.g. <c>$C2&gt;$D2</c>. It is
+    ///     written against the first data row (row 2) and Excel moves it down the column from there, so
+    ///     the row part stays relative while the column part is usually anchored with <c>$</c>.
+    /// </summary>
+    public string? Formula { get; set; }
+
+    /// <summary>
+    ///     Restyle the whole row rather than the cell that met the condition (default: false).
+    /// </summary>
+    public bool WholeRow { get; set; }
+
+    /// <summary>The colour the text takes when the rule applies.</summary>
+    public ExcelStyleColor FontColor { get; set; }
+
+    /// <summary>The colour the cells are filled with when the rule applies.</summary>
+    public ExcelStyleColor BackgroundColor { get; set; }
+
+    public bool Bold { get; set; }
+
+    public bool Italic { get; set; }
+}

--- a/Chsword.Excel2Object/Options/ExcelExporterOptions.cs
+++ b/Chsword.Excel2Object/Options/ExcelExporterOptions.cs
@@ -49,6 +49,12 @@ public class ExcelExporterOptions
     public bool DateTimeAsText { get; set; }
 
     /// <summary>
+    ///     Rules that restyle cells whose value meets a condition - Excel re-evaluates them as the sheet is
+    ///     edited, so the colours keep following the data.
+    /// </summary>
+    public IList<ConditionalFormat> ConditionalFormats { get; set; } = new List<ConditionalFormat>();
+
+    /// <summary>
     ///     Freeze the header row, so it stays in view while the sheet is scrolled (default: false).
     /// </summary>
     public bool FreezeHeader { get; set; }

--- a/README.md
+++ b/README.md
@@ -57,11 +57,15 @@ excel2obj generate-model orders.xlsx --class Order           # 由表头生成�
 - [x] 支持自动列宽 ✅ **v2.0.4 新增**
 - [x] 冻结首行与自动筛选 ✅ **v2.5.0 新增**
 - [x] 数据验证（下拉列表）✅ **v2.5.0 新增**
+- [x] 条件格式 ✅ **v2.6.0 新增**
 - [x] 支持 Excel 日期/日期时间/时间格式 ✅ **v2.0.4 新增**，导出为真正的日期单元格 ✅ **v2.4.0 新增** - 查看 [DateTimeFormats.md](DateTimeFormats.md)
 - [x] 公式列引用同一工作簿的其他 sheet ✅ **v2.1.0 新增** - 查看 [ExcelFunctions.md](ExcelFunctions.md)
 - [x] 公式内置函数库 ✅ **v2.3.0 新增** - 334 个 Excel 函数，10 个类别 - 查看 [ExcelFunctions.md](ExcelFunctions.md)
 
 ### 发布说明
+
+* **2026.09.12** - v2.6.0
+- [x] ✨ **新增:** 条件格式 `options.ConditionalFormats`：按列写规则（`Operator` + `Value`，`Between` 用 `Value2`，或直接给 `Formula`），命中时改字体颜色、加粗、倾斜、填充背景色；`WholeRow = true` 可整行高亮。规则由 Excel 求值，数据编辑后颜色跟着变，同一列可挂多条，`.xls` / `.xlsx` 都支持
 
 * **2026.09.12** - v2.5.0
 - [x] ✨ **新增:** `ExcelExporterOptions.FreezeHeader` 冻结首行，滚动时表头常驻；`ExcelExporterOptions.AutoFilter` 给表头挂上筛选下拉，范围覆盖本次写入的数据行。两项默认关闭，`.xls` / `.xlsx` 都支持
@@ -322,6 +326,40 @@ var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
 ```
 
 Excel 会把取值显示为下拉，并拒绝其他输入。追加导出用 `ExcelHelper.AppendObjectToExcelBytes(bytes, models, options => ...)` 同样可以设置这些选项。列表总长超过 255 字符、或取值里含逗号/引号时（Excel 行内列表放不下），自动改写到一张隐藏 sheet 上、由一个定义名称指向该区域，下拉再引用这个名称（`.xls` 无法让数据验证直接跨 sheet 引用），用法不变；`.xls` 与 `.xlsx` 都支持。导出空列表时下拉仍会挂在第一行，方便做填写模板。
+
+### 条件格式
+
+``` csharp
+var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
+{
+    // 金额大于 1 万的单元格标红加粗
+    options.ConditionalFormats.Add(new ConditionalFormat("金额")
+    {
+        Operator = ConditionalOperator.GreaterThan,
+        Value = 10000,
+        FontColor = ExcelStyleColor.Red,
+        Bold = true
+    });
+
+    // 整行高亮：状态为"急件"时整行黄底
+    options.ConditionalFormats.Add(new ConditionalFormat("状态")
+    {
+        Operator = ConditionalOperator.Equal,
+        Value = "急件",
+        WholeRow = true,
+        BackgroundColor = ExcelStyleColor.Yellow
+    });
+
+    // 也可以直接写 Excel 条件，按第一行数据（第 2 行）书写，列用 $ 锁定
+    options.ConditionalFormats.Add(new ConditionalFormat("金额")
+    {
+        Formula = "$B2>$C2",
+        BackgroundColor = ExcelStyleColor.LightGreen
+    });
+});
+```
+
+规则由 Excel 自己求值，数据被编辑后颜色会跟着变。`Value` 按类型写成 Excel 字面量（数字原样、字符串加引号、`DateTime` 写成 `DATE(y,m,d)`），`Between` / `NotBetween` 用 `Value2` 给出另一端。同一列可以挂多条规则，`.xls` 与 `.xlsx` 都支持。
 
 ### 在 ASP.NET MVC 中使用
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -55,11 +55,15 @@ See [Chsword.Excel2Object.Cli/README.md](Chsword.Excel2Object.Cli/README.md).
 - [x] Support auto width column ✅ **New in v2.0.4**
 - [x] Frozen header row and filter dropdowns ✅ **New in v2.5.0**
 - [x] Data validation (dropdown lists) ✅ **New in v2.5.0**
+- [x] Conditional formatting ✅ **New in v2.6.0**
 - [x] Support date/datetime/time formats in Excel ✅ **New in v2.0.4**, exported as real date cells ✅ **New in v2.4.0** - See [DateTimeFormats.md](DateTimeFormats.md)
 - [x] Formula columns referencing other sheets of the same workbook ✅ **New in v2.1.0** - See [ExcelFunctions.md](ExcelFunctions.md)
 - [x] Built-in formula function library ✅ **New in v2.3.0** - 334 Excel functions in 10 categories - See [ExcelFunctions.md](ExcelFunctions.md)
 
 ### Release Notes
+
+* **2026.09.12** - v2.6.0
+- [x] ✨ **NEW:** Conditional formatting through `options.ConditionalFormats`: a rule per column (`Operator` + `Value`, `Value2` for `Between`, or a `Formula` of your own) restyles the cells it matches - font colour, bold, italic, background fill - and `WholeRow = true` colours the whole row. Excel evaluates the rules, so the colours follow the data as it is edited; a column can carry several, and both `.xls` and `.xlsx` support them
 
 * **2026.09.12** - v2.5.0
 - [x] ✨ **NEW:** `ExcelExporterOptions.FreezeHeader` freezes the header row so it stays in view while scrolling, and `ExcelExporterOptions.AutoFilter` puts Excel's filter dropdowns on it over the rows this export wrote. Both are off by default and work in `.xls` as well as `.xlsx`
@@ -319,6 +323,40 @@ var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
 ```
 
 Excel shows the values as a dropdown and rejects anything else. `ExcelHelper.AppendObjectToExcelBytes(bytes, models, options => ...)` takes the same options when appending a sheet. A list Excel cannot hold inline - over 255 characters in total, or a value carrying a comma or a quote - is written to a hidden sheet that a defined name points at, which the dropdown then reads (a `.xls` validation cannot reference another sheet directly); nothing about how it is used changes, and both `.xls` and `.xlsx` support it. An export with no rows still gets the dropdown on its first row, so it works as a template to fill in.
+
+### Conditional Formatting
+
+``` csharp
+var bytes = ExcelHelper.ObjectToExcelBytes(models, options =>
+{
+    // amounts over 10,000 turn red and bold
+    options.ConditionalFormats.Add(new ConditionalFormat("Amount")
+    {
+        Operator = ConditionalOperator.GreaterThan,
+        Value = 10000,
+        FontColor = ExcelStyleColor.Red,
+        Bold = true
+    });
+
+    // the whole row turns yellow when the status says so
+    options.ConditionalFormats.Add(new ConditionalFormat("Status")
+    {
+        Operator = ConditionalOperator.Equal,
+        Value = "Urgent",
+        WholeRow = true,
+        BackgroundColor = ExcelStyleColor.Yellow
+    });
+
+    // or write the Excel condition yourself, against the first data row (row 2), anchoring the column
+    options.ConditionalFormats.Add(new ConditionalFormat("Amount")
+    {
+        Formula = "$B2>$C2",
+        BackgroundColor = ExcelStyleColor.LightGreen
+    });
+});
+```
+
+Excel evaluates the rules itself, so the colours follow the data as it is edited. `Value` is written as the Excel literal for its type (a number as it is, a string quoted, a `DateTime` as `DATE(y,m,d)`), and `Between` / `NotBetween` take the other end in `Value2`. A column can carry several rules, and both `.xls` and `.xlsx` support them.
 
 ### Use with ASP.NET MVC
 


### PR DESCRIPTION
## 背景

`[ExcelColumn]` 的样式是写死在单元格上的：导出时是什么颜色，之后就一直是什么颜色。而"金额超过一万标红""状态是急件整行黄底"这类需求，要的是**规则**——数据被编辑后颜色要跟着变。这只能交给 Excel 的条件格式。

## 变更

```csharp
options.ConditionalFormats.Add(new ConditionalFormat("金额")
{
    Operator = ConditionalOperator.GreaterThan,
    Value = 10000,
    FontColor = ExcelStyleColor.Red,
    Bold = true
});

// 整行高亮
options.ConditionalFormats.Add(new ConditionalFormat("状态")
{
    Operator = ConditionalOperator.Equal,
    Value = "急件",
    WholeRow = true,
    BackgroundColor = ExcelStyleColor.Yellow
});

// 或者直接写 Excel 条件，按第一行数据（第 2 行）书写
options.ConditionalFormats.Add(new ConditionalFormat("金额") { Formula = "$B2>$C2", ... });
```

- 比较运算符：`Equal` / `NotEqual` / `GreaterThan` / `LessThan` / `GreaterThanOrEqual` / `LessThanOrEqual` / `Between` / `NotBetween`（后两者用 `Value2` 给另一端）
- `Value` 按类型写成 Excel 字面量：数字原样，字符串加引号（内部引号按 Excel 规则转义），`DateTime` 写成 `DATE(y,m,d)`，`bool` 写成 `TRUE`/`FALSE`
- 命中时可改字体颜色、加粗、倾斜、填充背景色（沿用既有的 `ExcelStyleColor`）
- `WholeRow = true` 时整行上色。Excel 的单元格比较规则只作用于规则所在单元格，所以这种情况会把比较转写成锚定该列的表达式（`$B2>10000`）
- 同一列可以挂多条规则；空数据导出也会保留规则，便于做模板
- 列标题不存在、比较缺 `Value` 都会抛带上下文的 `Excel2ObjectException`

## 测试

新增 `ConditionalFormatTest`（11 个用例），覆盖两种文件格式、各类字面量、`Between`、自定义公式、整行、多规则、空数据与两种报错。全套 296 个测试通过，所有 TFM 构建 0 警告。

版本 2.5.0 → 2.6.0，README / README_EN 补了示例与发布说明。

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)